### PR TITLE
feat: only include snos output for settlement da

### DIFF
--- a/saya/core/src/prover/atlantic/layout_bridge.rs
+++ b/saya/core/src/prover/atlantic/layout_bridge.rs
@@ -15,6 +15,7 @@ use crate::{
         Prover, ProverBuilder, RecursiveProof, SnosProof,
     },
     service::{Daemon, FinishHandle, ShutdownHandle},
+    utils::calculate_output,
 };
 
 const PROOF_STATUS_POLL_INTERVAL: Duration = Duration::from_secs(10);
@@ -117,7 +118,7 @@ impl AtlanticLayoutBridgeProver {
 
             let new_proof = RecursiveProof {
                 block_number: new_snos_proof.block_number,
-                snos_proof: parsed_snos_proof,
+                snos_output: calculate_output(&parsed_snos_proof),
                 layout_bridge_proof: verifier_proof,
             };
 

--- a/saya/core/src/prover/mod.rs
+++ b/saya/core/src/prover/mod.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use serde::Serialize;
+use starknet_types_core::felt::Felt;
 use swiftness_stark::types::StarkProof;
 use tokio::sync::mpsc::{Receiver, Sender};
 
@@ -41,7 +42,7 @@ pub struct SnosProof<P> {
 #[derive(Debug, Clone, Serialize)]
 pub struct RecursiveProof {
     pub block_number: u64,
-    pub snos_proof: StarkProof,
+    pub snos_output: Vec<Felt>,
     pub layout_bridge_proof: StarkProof,
 }
 

--- a/saya/core/src/settlement/piltover.rs
+++ b/saya/core/src/settlement/piltover.rs
@@ -180,7 +180,7 @@ impl PiltoverSettlementBackend {
                 selector: selector!("update_state"),
                 calldata: {
                     let calldata = UpdateStateCalldata {
-                        snos_output: calculate_output(&new_da.full_payload.snos_proof),
+                        snos_output: new_da.full_payload.snos_output,
                         program_output: calculate_output(&new_da.full_payload.layout_bridge_proof),
                         onchain_data_hash: Felt::ZERO,
                         onchain_data_size: U256::from_words(0, 0),


### PR DESCRIPTION
Currently when running in `persistent` mode both the `snos` and `layout_bridge` proofs are made available in full. This is wasteful as the soundness of `snos` output is already verified by the `layout_bridge` proof. Therefore, only the output from `snos` needs to be included.

This PR does exactly that by replacing the full `snos` proof with just its output, whose hash should be part of the `layout_bridge` output for verification.