### PR TITLE
feat: remove proof from persistent mode da

### DIFF
--- a/saya/core/src/data_availability/celestia.rs
+++ b/saya/core/src/data_availability/celestia.rs
@@ -8,7 +8,7 @@ use url::Url;
 use crate::{
     data_availability::{
         DataAvailabilityBackend, DataAvailabilityBackendBuilder, DataAvailabilityCursor,
-        DataAvailabilityPacket, DataAvailabilityPayload, DataAvailabilityPointer,
+        DataAvailabilityPacketContext, DataAvailabilityPayload, DataAvailabilityPointer,
     },
     service::{Daemon, FinishHandle, ShutdownHandle},
 };
@@ -56,10 +56,11 @@ where
                 .await
                 .unwrap();
 
-            let packet = DataAvailabilityPacket {
-                prev: self.last_pointer,
-                content: new_proof.clone(),
-            };
+            let packet = new_proof
+                .clone()
+                .into_packet(DataAvailabilityPacketContext {
+                    prev: self.last_pointer,
+                });
 
             // TODO: error handling
             let mut serialized_packet: Vec<u8> = Vec::new();
@@ -96,7 +97,7 @@ where
                     height: celestia_block,
                     commitment,
                 },
-                full_payload: packet.content,
+                full_payload: new_proof,
             };
 
             // Since the channel is bounded, it's possible


### PR DESCRIPTION
DA posting in `persistent` mode is now limited to just `snos` output, since proofs are already verified by the settlement layer.

> [!NOTE]
>
> Since `piltover` already taeks full `snos` output for the `update_state` call, technically speaking no external DA is needed. See the note in the newly added code comments on why this is still kept in place for now.