### PR TITLE
chore: scripts for generating cairo program artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/programs/
 /target/

--- a/scripts/entrypoints/layout_bridge.sh
+++ b/scripts/entrypoints/layout_bridge.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$CAIRO_VERSION" ]; then
+  echo "CAIRO_VERSION not set" >&2
+  exit 1
+fi
+
+CAIRO_VERSION=${CAIRO_VERSION#"v"}
+
+if [ "$CAIRO_VERSION" = "0.13.2.1" ]; then
+  # Doing this as v0.13.2.1 is not tagged
+  git clone --recursive https://github.com/starkware-libs/cairo-lang -b v0.13.3 --depth 2 /src
+  cd /src && git checkout a86e92bfde9c171c0856d7b46580c66e004922f3
+else
+  git clone --recursive https://github.com/starkware-libs/cairo-lang -b v$CAIRO_VERSION --depth 1 /src
+fi
+
+# Patch to make the verifier work with `dynamic` layout
+sed -i s/all_cairo/dynamic/g /src/src/starkware/cairo/cairo_verifier/layouts/all_cairo/cairo_verifier.cairo
+
+cd /src/src && cairo-compile --no_debug_info --proof_mode --output /output/layout_bridge.json starkware/cairo/cairo_verifier/layouts/all_cairo/cairo_verifier.cairo

--- a/scripts/entrypoints/snos.sh
+++ b/scripts/entrypoints/snos.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$CAIRO_VERSION" ]; then
+  echo "CAIRO_VERSION not set" >&2
+  exit 1
+fi
+
+CAIRO_VERSION=${CAIRO_VERSION#"v"}
+
+if [ "$CAIRO_VERSION" = "0.13.2.1" ]; then
+  # Doing this as v0.13.2.1 is not tagged
+  git clone --recursive https://github.com/starkware-libs/cairo-lang -b v0.13.3 --depth 2 /src
+  cd /src && git checkout a86e92bfde9c171c0856d7b46580c66e004922f3
+else
+  git clone --recursive https://github.com/starkware-libs/cairo-lang -b v$CAIRO_VERSION --depth 1 /src
+fi
+
+cd /src/src && cairo-compile --no_debug_info --output /output/snos.json starkware/starknet/core/os/os.cairo

--- a/scripts/generate_layout_bridge.sh
+++ b/scripts/generate_layout_bridge.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Uses Docker to deterministically generate the `layout_bridge` program artifact.
 #

--- a/scripts/generate_layout_bridge.sh
+++ b/scripts/generate_layout_bridge.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# Uses Docker to deterministically generate the `layout_bridge` program artifact.
+#
+# In environments that need `sudo` to run `docker` commands, set the `SUDO` variable to `sudo`:
+#
+# $ SUDO=sudo ./generate_layout_bridge.sh
+
+set -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( dirname -- $SCRIPT_DIR )
+
+CAIRO_VERSION="0.13.3"
+COMPILER_VERSION="0.13.2"
+
+mkdir -p $REPO_ROOT/programs
+
+$SUDO docker run -it --rm \
+  -v "$REPO_ROOT/programs:/output" \
+  -v "$SCRIPT_DIR/entrypoints/layout_bridge.sh:/entry:ro" \
+  -e "CAIRO_VERSION=$CAIRO_VERSION" \
+  --entrypoint "/entry" \
+  starknet/cairo-lang:$COMPILER_VERSION
+
+$SUDO docker run --rm \
+  -v "$REPO_ROOT/programs:/output" \
+  --user root \
+  tmknom/prettier:3.2.5 \
+  --write "/output/layout_bridge.json"

--- a/scripts/generate_snos.sh
+++ b/scripts/generate_snos.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Uses Docker to deterministically generate the `snos` program artifact.
 #

--- a/scripts/generate_snos.sh
+++ b/scripts/generate_snos.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# Uses Docker to deterministically generate the `snos` program artifact.
+#
+# In environments that need `sudo` to run `docker` commands, set the `SUDO` variable to `sudo`:
+#
+# $ SUDO=sudo ./generate_snos.sh
+
+set -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( dirname -- $SCRIPT_DIR )
+
+CAIRO_VERSION="0.13.2.1"
+COMPILER_VERSION="0.13.2"
+
+mkdir -p $REPO_ROOT/programs
+
+$SUDO docker run -it --rm \
+  -v "$REPO_ROOT/programs:/output" \
+  -v "$SCRIPT_DIR/entrypoints/snos.sh:/entry:ro" \
+  -e "CAIRO_VERSION=$CAIRO_VERSION" \
+  --entrypoint "/entry" \
+  starknet/cairo-lang:$COMPILER_VERSION
+
+$SUDO docker run --rm \
+  -v "$REPO_ROOT/programs:/output" \
+  --user root \
+  tmknom/prettier:3.2.5 \
+  --write "/output/snos.json"


### PR DESCRIPTION
Adds 2 scripts for generating the `snos` and `bridge_layout` programs required to run `saya`.

> [!NOTE]
>
> Compiling `bridge_layout` requires a large amount of RAM (around 32 GB).

The generated artifacts have been compared to the 2 large files previously committed to this repo via LFS before the rewrite:

- `snos`: The script included in this PR uses `--no_debug_info` but the original LFS file seems to have been compiled without that flag. The script in the PR keeps the flag as it results in smaller artifacts, but when removed, it generates the **exact same** Cairo program artifact as the LFS file except for debug file paths.
- `layout_bridge`: The script generates the **exact same** Cario program with the exact same SHA256 checksum.

These scripts clearly demonstrate how the programs are compiled. They're much more preferable than opaque artifact files pulled from LFS. They're also much easier to upgrade.