### PR TITLE
chore: add `Dockerfile`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+/target/
+/.dockerignore
+/Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM rust:alpine AS build
+
+RUN apk add --update alpine-sdk linux-headers libressl-dev
+
+COPY . /src
+WORKDIR /src
+
+RUN cargo build --release
+
+FROM alpine
+
+LABEL org.opencontainers.image.source=https://github.com/dojoengine/saya
+
+COPY --from=build /src/target/release/saya /usr/bin/
+
+ENTRYPOINT [ "saya" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,28 @@ FROM rust:alpine AS build
 
 RUN apk add --update alpine-sdk linux-headers libressl-dev
 
-COPY . /src
 WORKDIR /src
+COPY ./rust-toolchain.toml /src/
 
-RUN cargo build --release
+# Cache Docker layer for nightly toolchain installation
+RUN cargo --version
+
+COPY . /src/
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/src/target \
+    cargo build --release
+
+RUN --mount=type=cache,target=/src/target \
+    mkdir ./build && \
+    cp ./target/release/saya ./build/
 
 FROM alpine
 
 LABEL org.opencontainers.image.source=https://github.com/dojoengine/saya
 
-COPY --from=build /src/target/release/saya /usr/bin/
+COPY --from=build /src/build/saya /usr/bin/
 COPY programs /programs
 
 ENTRYPOINT [ "saya" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Consider building the cairo programs before building the image to embed them.
+# Consider compiling the cairo programs before building the image to embed them.
 
 FROM rust:alpine AS build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# Consider building the cairo programs before building the image to embed them.
+
 FROM rust:alpine AS build
 
 RUN apk add --update alpine-sdk linux-headers libressl-dev
@@ -12,5 +14,6 @@ FROM alpine
 LABEL org.opencontainers.image.source=https://github.com/dojoengine/saya
 
 COPY --from=build /src/target/release/saya /usr/bin/
+COPY programs /programs
 
 ENTRYPOINT [ "saya" ]


### PR DESCRIPTION
This PR adds the `Dockerfile` to build Saya. The two programs required by Saya are included in the image. It makes it a bit larger (`~30MB` more), but seems the most convenient solution at the moment.

@xJonathanLEI currently I'm building the images locally for @steebchen to iterate on slot integration. Will address the CI in an other PR, where a container will be pushed upon release.
