### PR TITLE
feat: noop da backend

### DIFF
--- a/bin/saya/src/persistent.rs
+++ b/bin/saya/src/persistent.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 use saya_core::{
     block_ingestor::PollingBlockIngestorBuilder,
-    data_availability::CelestiaDataAvailabilityBackendBuilder,
+    data_availability::NoopDataAvailabilityBackendBuilder,
     orchestrator::PersistentOrchestratorBuilder,
     prover::{
         AtlanticLayoutBridgeProverBuilder, AtlanticSnosProverBuilder, RecursiveProverBuilder,
@@ -47,12 +47,6 @@ struct Start {
     /// Atlantic prover API key
     #[clap(long, env)]
     atlantic_key: String,
-    /// Celestia RPC endpoint URL
-    #[clap(long, env)]
-    celestia_rpc: Url,
-    /// Celestia RPC node auth token
-    #[clap(long, env)]
-    celestia_token: String,
     /// Settlement network integrity contract address
     #[clap(long, env)]
     settlement_integrity_address: Felt,
@@ -91,8 +85,7 @@ impl Start {
             AtlanticSnosProverBuilder::new(self.atlantic_key.clone()),
             AtlanticLayoutBridgeProverBuilder::new(self.atlantic_key, layout_bridge),
         );
-        let da_builder =
-            CelestiaDataAvailabilityBackendBuilder::new(self.celestia_rpc, self.celestia_token);
+        let da_builder = NoopDataAvailabilityBackendBuilder::new();
         let settlement_builder = PiltoverSettlementBackendBuilder::new(
             self.settlement_rpc,
             self.settlement_integrity_address,

--- a/saya/core/src/data_availability/celestia.rs
+++ b/saya/core/src/data_availability/celestia.rs
@@ -93,10 +93,10 @@ where
 
             let new_cursor = DataAvailabilityCursor {
                 block_number: new_proof.block_number(),
-                pointer: DataAvailabilityPointer {
+                pointer: Some(DataAvailabilityPointer {
                     height: celestia_block,
                     commitment,
-                },
+                }),
                 full_payload: new_proof,
             };
 

--- a/saya/core/src/data_availability/mod.rs
+++ b/saya/core/src/data_availability/mod.rs
@@ -1,11 +1,13 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use starknet_types_core::felt::Felt;
 use swiftness_stark::types::StarkProof;
 use tokio::sync::mpsc::{Receiver, Sender};
 
 mod celestia;
 pub use celestia::{CelestiaDataAvailabilityBackend, CelestiaDataAvailabilityBackendBuilder};
+
+mod noop;
+pub use noop::{NoopDataAvailabilityBackend, NoopDataAvailabilityBackendBuilder};
 
 use crate::{prover::SnosProof, service::Daemon};
 
@@ -72,10 +74,7 @@ pub struct SovereignPacket {
 /// the state diff section) needs to be made available anyway, so we might as well just keep the DA
 /// posting mechanism in place for now.
 #[derive(Debug, Serialize, Deserialize)]
-pub struct PersistentPacket {
-    /// The output of the `snos` Cairo program.
-    pub snos_output: Vec<Felt>,
-}
+pub struct PersistentPacket;
 
 // TODO: abstract over this to allow other DA backends.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -91,8 +90,8 @@ pub struct DataAvailabilityPointer {
 pub struct DataAvailabilityCursor<P> {
     /// State transition block.
     pub block_number: u64,
-    /// Pointer to location of data availability.
-    pub pointer: DataAvailabilityPointer,
+    /// Pointer to location of data availability. `None` if data publishing was not performed.
+    pub pointer: Option<DataAvailabilityPointer>,
     /// Full content of the payload.
     pub full_payload: P,
 }

--- a/saya/core/src/data_availability/noop.rs
+++ b/saya/core/src/data_availability/noop.rs
@@ -1,0 +1,123 @@
+use anyhow::Result;
+use log::debug;
+use tokio::sync::mpsc::{Receiver, Sender};
+
+use crate::{
+    data_availability::{
+        DataAvailabilityBackend, DataAvailabilityBackendBuilder, DataAvailabilityCursor,
+        DataAvailabilityPayload, DataAvailabilityPointer,
+    },
+    service::{Daemon, FinishHandle, ShutdownHandle},
+};
+
+/// A placeholder to fill the gap where a data availability backend is expected but no data needs to
+/// be published.
+///
+/// Upon receiving a payload, this backend immediately delivers it to the output channel.
+#[derive(Debug)]
+pub struct NoopDataAvailabilityBackend<P> {
+    proof_channel: Receiver<P>,
+    cursor_channel: Sender<DataAvailabilityCursor<P>>,
+    finish_handle: FinishHandle,
+}
+
+#[derive(Debug, Default)]
+pub struct NoopDataAvailabilityBackendBuilder<P> {
+    proof_channel: Option<Receiver<P>>,
+    cursor_channel: Option<Sender<DataAvailabilityCursor<P>>>,
+}
+
+impl<P> NoopDataAvailabilityBackend<P>
+where
+    P: DataAvailabilityPayload,
+{
+    async fn run(mut self) {
+        loop {
+            let new_proof = tokio::select! {
+                _ = self.finish_handle.shutdown_requested() => break,
+                new_proof = self.proof_channel.recv() => new_proof,
+            };
+
+            // This should be fine for now as provers wouldn't drop senders. This might change in
+            // the future.
+            let new_proof = new_proof.unwrap();
+
+            let new_cursor = DataAvailabilityCursor {
+                block_number: new_proof.block_number(),
+                pointer: None,
+                full_payload: new_proof,
+            };
+
+            // Since the channel is bounded, it's possible
+            tokio::select! {
+                _ = self.finish_handle.shutdown_requested() => break,
+                _ = self.cursor_channel.send(new_cursor) => {},
+            }
+        }
+
+        debug!("Graceful shutdown finished");
+        self.finish_handle.finish();
+    }
+}
+
+impl<P> NoopDataAvailabilityBackendBuilder<P> {
+    pub fn new() -> Self {
+        Self {
+            proof_channel: None,
+            cursor_channel: None,
+        }
+    }
+}
+
+impl<P> DataAvailabilityBackendBuilder for NoopDataAvailabilityBackendBuilder<P>
+where
+    P: DataAvailabilityPayload + 'static,
+{
+    type Backend = NoopDataAvailabilityBackend<P>;
+
+    fn build(self) -> Result<Self::Backend> {
+        Ok(NoopDataAvailabilityBackend {
+            proof_channel: self
+                .proof_channel
+                .ok_or_else(|| anyhow::anyhow!("`proof_channel` not set"))?,
+            cursor_channel: self
+                .cursor_channel
+                .ok_or_else(|| anyhow::anyhow!("`cursor_channel` not set"))?,
+            finish_handle: FinishHandle::new(),
+        })
+    }
+
+    fn last_pointer(self, _last_pointer: Option<DataAvailabilityPointer>) -> Self {
+        self
+    }
+
+    fn proof_channel(mut self, proof_channel: Receiver<P>) -> Self {
+        self.proof_channel = Some(proof_channel);
+        self
+    }
+
+    fn cursor_channel(mut self, cursor_channel: Sender<DataAvailabilityCursor<P>>) -> Self {
+        self.cursor_channel = Some(cursor_channel);
+        self
+    }
+}
+
+impl<P> DataAvailabilityBackend for NoopDataAvailabilityBackend<P>
+where
+    P: DataAvailabilityPayload + 'static,
+{
+    type Payload = P;
+}
+
+impl<P> Daemon for NoopDataAvailabilityBackend<P>
+where
+    P: DataAvailabilityPayload + 'static,
+{
+    fn shutdown_handle(&self) -> ShutdownHandle {
+        self.finish_handle.shutdown_handle()
+    }
+
+    fn start(self) {
+        tokio::spawn(self.run());
+    }
+}

--- a/saya/core/src/orchestrator/persistent.rs
+++ b/saya/core/src/orchestrator/persistent.rs
@@ -101,8 +101,6 @@ where
         let (settle_cursor_tx, settle_cursor_rx) =
             tokio::sync::mpsc::channel::<SettlementCursor>(SETTLE_CURSOR_BUFFER_SIZE);
 
-        let da_builder = self.da_builder.last_pointer(None);
-
         let settlement = self
             .settlement_builder
             .da_channel(da_cursor_rx)
@@ -126,7 +124,8 @@ where
             .build()
             .unwrap();
 
-        let da = da_builder
+        let da = self
+            .da_builder
             .proof_channel(proof_rx)
             .cursor_channel(da_cursor_tx)
             .build()

--- a/saya/core/src/orchestrator/sovereign.rs
+++ b/saya/core/src/orchestrator/sovereign.rs
@@ -169,10 +169,13 @@ where
             // in the future.
             let new_cursor = new_cursor.unwrap();
 
+            // TODO: error handling
+            let da_pointer = new_cursor.pointer.unwrap();
+
             self.storage
                 .set_chain_head(BlockWithDa {
                     height: new_cursor.block_number,
-                    da_pointer: new_cursor.pointer,
+                    da_pointer,
                 })
                 .await;
 

--- a/saya/core/src/prover/mod.rs
+++ b/saya/core/src/prover/mod.rs
@@ -74,8 +74,6 @@ impl DataAvailabilityPayload for RecursiveProof {
     }
 
     fn into_packet(self, _ctx: DataAvailabilityPacketContext) -> Self::Packet {
-        PersistentPacket {
-            snos_output: self.snos_output,
-        }
+        PersistentPacket
     }
 }


### PR DESCRIPTION
The current `piltover` implementation does not require any external DA, yet having a DA step in the `persistent` pileline would be helpful in the future when different DA modes are introduced. So instead of removing the step altogether, a filler void DA backend is added.