### PR TITLE
docs: fix sepolia integrity addr and README fmt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@ CELESTIA_TOKEN=
 # https://github.com/HerodotusDev/integrity/blob/95fa6cd82b28086f4676070ced5fcb10db4b73a5/deployed_contracts.md
 # Currently, the layout bridge is verified using `recursive_with_poseidon` verifier.
 ATLANTIC_KEY=
-SETTLEMENT_INTEGRITY_ADDRESS=0x05E529706944049BB2Be637a26A4d78b32e554Ecaa54D0e608F2Fa9f1472c516
+SETTLEMENT_INTEGRITY_ADDRESS=0x04ce7851f00b6c3289674841fd7a1b96b6fd41ed1edc248faccd672c26371b8c
 # Use the scripts in `./scripts` to compile the cairo programs.
 SNOS_PROGRAM=./programs/snos.json
 LAYOUT_BRIDGE_PROGRAM=./programs/layout_bridge.json

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Saya is a settlement service for Katana.
 - Herodotus Dev account with API key, which can be obtained from https://staging.dashboard.herodotus.dev.
 
 ### Sovereign mode
+
 - Celestia node up and running that you can send blob to using a celestia token (only for sovereign mode at the moment).
 
 ### Persistent mode
+
 - Piltover settlement contract must be deployed on the settlement chain, see [piltover repository](https://github.com/keep-starknet-strange/piltover) or `katana init` can handle it too.
 - An account on the settlement chain with funds to verify the proof.
 


### PR DESCRIPTION
Minor doc update:

- the `.env.example` file now correctly uses the fact registry address for `SETTLEMENT_INTEGRITY_ADDRESS`.
- ran `prettier` on `README.md`.