### PR TITLE
feat: bump Starknet OS to v0.13.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,7 +1239,7 @@ dependencies = [
 [[package]]
 name = "cairo-type-derive"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=6e0514d#6e0514d3cc33d7e2041cfd4a72d0ceca16aaf3c3"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=e4599fe#e4599fe859955f6763f51306605b88e7967f40b2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "prove_block"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=6e0514d#6e0514d3cc33d7e2041cfd4a72d0ceca16aaf3c3"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=e4599fe#e4599fe859955f6763f51306605b88e7967f40b2"
 dependencies = [
  "anyhow",
  "blockifier",
@@ -4700,7 +4700,7 @@ dependencies = [
 [[package]]
 name = "rpc-client"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=6e0514d#6e0514d3cc33d7e2041cfd4a72d0ceca16aaf3c3"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=e4599fe#e4599fe859955f6763f51306605b88e7967f40b2"
 dependencies = [
  "log",
  "reqwest 0.11.27",
@@ -4715,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "rpc-replay"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=6e0514d#6e0514d3cc33d7e2041cfd4a72d0ceca16aaf3c3"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=e4599fe#e4599fe859955f6763f51306605b88e7967f40b2"
 dependencies = [
  "blockifier",
  "cairo-lang-starknet-classes",
@@ -5869,7 +5869,7 @@ dependencies = [
 [[package]]
 name = "starknet-os"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=6e0514d#6e0514d3cc33d7e2041cfd4a72d0ceca16aaf3c3"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=e4599fe#e4599fe859955f6763f51306605b88e7967f40b2"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -5918,7 +5918,7 @@ dependencies = [
 [[package]]
 name = "starknet-os-types"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/snos?rev=6e0514d#6e0514d3cc33d7e2041cfd4a72d0ceca16aaf3c3"
+source = "git+https://github.com/keep-starknet-strange/snos?rev=e4599fe#e4599fe859955f6763f51306605b88e7967f40b2"
 dependencies = [
  "blockifier",
  "cairo-lang-starknet-classes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ hex = { version = "0.4.3", default-features = false }
 integrity = { version = "0.1.0", default-features = false, features = ["recursive_with_poseidon", "keccak_160_lsb", "stone6"] }
 log = "0.4.22"
 num-traits = { version = "0.2.19", default-features = false }
-prove_block = { git = "https://github.com/keep-starknet-strange/snos", rev = "6e0514d" }
+prove_block = { git = "https://github.com/keep-starknet-strange/snos", rev = "e4599fe" }
 reqwest = { version = "0.12.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }
 serde = { version = "1.0.217", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.134", default-features = false }

--- a/scripts/generate_snos.sh
+++ b/scripts/generate_snos.sh
@@ -11,8 +11,8 @@ set -e
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT=$( dirname -- $SCRIPT_DIR )
 
-CAIRO_VERSION="0.13.2.1"
-COMPILER_VERSION="0.13.2"
+CAIRO_VERSION="0.13.3"
+COMPILER_VERSION="0.13.3"
 
 mkdir -p $REPO_ROOT/programs
 


### PR DESCRIPTION
Tested and works with patched `piltover` after: https://github.com/keep-starknet-strange/piltover/pull/50.