### PR TITLE
feat: hash Cairo programs

### DIFF
--- a/.github/workflows/build_programs.yml
+++ b/.github/workflows/build_programs.yml
@@ -1,0 +1,31 @@
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+  workflow_dispatch:
+
+name: "Build and hash programs"
+
+jobs:
+  build:
+    name: "Build and hash ${{ matrix.name }}"
+    runs-on: "${{ matrix.runner }}"
+
+    strategy:
+      matrix:
+        include:
+          - name: "snos"
+            runner: "ubuntu-latest-8-cores"
+            script: "generate_snos.sh"
+          - name: "layout_bridge"
+            runner: "ubuntu-latest-16-cores"
+            script: "generate_layout_bridge.sh"
+
+    steps:
+      - name: "Checkout source code"
+        uses: "actions/checkout@v4"
+
+      - name: "Build and hash program"
+        run: |
+          ./scripts/${{ matrix.script }}

--- a/scripts/entrypoints/hash_program.py
+++ b/scripts/entrypoints/hash_program.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+import json
+
+from starkware.cairo.bootloaders.hash_program import compute_program_hash_chain
+from starkware.cairo.lang.compiler.program import Program
+
+
+if __name__ == "__main__":
+    compiled_program = Program.Schema().load(json.load(open("/program.json")))
+    program_hash = hex(
+        compute_program_hash_chain(program=compiled_program, use_poseidon=False)
+    )
+
+    print(f"Program hash:\n{program_hash}")

--- a/scripts/generate_layout_bridge.sh
+++ b/scripts/generate_layout_bridge.sh
@@ -16,7 +16,7 @@ COMPILER_VERSION="0.13.2"
 
 mkdir -p $REPO_ROOT/programs
 
-$SUDO docker run -it --rm \
+$SUDO docker run --rm \
   -v "$REPO_ROOT/programs:/output" \
   -v "$SCRIPT_DIR/entrypoints/layout_bridge.sh:/entry:ro" \
   -e "CAIRO_VERSION=$CAIRO_VERSION" \
@@ -28,3 +28,9 @@ $SUDO docker run --rm \
   --user root \
   tmknom/prettier:3.2.5 \
   --write "/output/layout_bridge.json"
+
+$SUDO docker run --rm \
+  -v "$REPO_ROOT/programs/layout_bridge.json:/program.json" \
+  -v "$SCRIPT_DIR/entrypoints/hash_program.py:/entry:ro" \
+  --entrypoint "/entry" \
+  starknet/cairo-lang:$COMPILER_VERSION

--- a/scripts/generate_snos.sh
+++ b/scripts/generate_snos.sh
@@ -16,7 +16,7 @@ COMPILER_VERSION="0.13.3"
 
 mkdir -p $REPO_ROOT/programs
 
-$SUDO docker run -it --rm \
+$SUDO docker run --rm \
   -v "$REPO_ROOT/programs:/output" \
   -v "$SCRIPT_DIR/entrypoints/snos.sh:/entry:ro" \
   -e "CAIRO_VERSION=$CAIRO_VERSION" \
@@ -28,3 +28,9 @@ $SUDO docker run --rm \
   --user root \
   tmknom/prettier:3.2.5 \
   --write "/output/snos.json"
+
+$SUDO docker run --rm \
+  -v "$REPO_ROOT/programs/snos.json:/program.json" \
+  -v "$SCRIPT_DIR/entrypoints/hash_program.py:/entry:ro" \
+  --entrypoint "/entry" \
+  starknet/cairo-lang:$COMPILER_VERSION


### PR DESCRIPTION
Updates the `generate_*` scripts to include the program hash computation step.

Also adds a CI workflow for making sure these scripts run successfully.