### PR TITLE
feat: add PersistentTEE orchestrator, BlockOrderer, and fix sovereign block ordering

### DIFF
--- a/bin/saya/src/any.rs
+++ b/bin/saya/src/any.rs
@@ -149,17 +149,17 @@ where
         })
     }
 
-    fn input_channel(
-        self,
-        block_channel: Receiver<<Self::Stage as PipelineStage>::Input>,
-    ) -> Self {
+    fn input_channel(self, block_channel: Receiver<<Self::Stage as PipelineStage>::Input>) -> Self {
         match self {
             Self::Atlantic(inner) => Self::Atlantic(inner.input_channel(block_channel)),
             Self::Mock(inner) => Self::Mock(inner.input_channel(block_channel)),
         }
     }
 
-    fn output_channel(self, output_channel: Sender<<Self::Stage as PipelineStage>::Output>) -> Self {
+    fn output_channel(
+        self,
+        output_channel: Sender<<Self::Stage as PipelineStage>::Output>,
+    ) -> Self {
         match self {
             Self::Atlantic(inner) => Self::Atlantic(inner.output_channel(output_channel)),
             Self::Mock(inner) => Self::Mock(inner.output_channel(output_channel)),

--- a/bin/saya/src/any.rs
+++ b/bin/saya/src/any.rs
@@ -9,7 +9,7 @@ use saya_core::{
     },
     prover::{
         AtlanticLayoutBridgeProver, AtlanticLayoutBridgeProverBuilder, MockLayoutBridgeProver,
-        MockLayoutBridgeProverBuilder, Prover, ProverBuilder, SnosProof,
+        MockLayoutBridgeProverBuilder, PipelineStage, PipelineStageBuilder, SnosProof,
     },
     service::{Daemon, ShutdownHandle},
     storage::PersistantStorage,
@@ -109,12 +109,12 @@ where
     }
 }
 
-impl<DB> Prover for AnyLayoutBridgeProver<DB>
+impl<DB> PipelineStage for AnyLayoutBridgeProver<DB>
 where
     DB: PersistantStorage + Send + Sync + Clone + 'static,
 {
-    type Statement = SnosProof<String>;
-    type BlockInfo = BlockInfo;
+    type Input = SnosProof<String>;
+    type Output = BlockInfo;
 }
 
 impl<DB> Daemon for AnyLayoutBridgeProver<DB>
@@ -136,33 +136,33 @@ where
     }
 }
 
-impl<DB> ProverBuilder for AnyLayoutBridgeProverBuilder<DB>
+impl<DB> PipelineStageBuilder for AnyLayoutBridgeProverBuilder<DB>
 where
     DB: PersistantStorage + Send + Sync + Clone + 'static,
 {
-    type Prover = AnyLayoutBridgeProver<DB>;
+    type Stage = AnyLayoutBridgeProver<DB>;
 
-    fn build(self) -> Result<Self::Prover> {
+    fn build(self) -> Result<Self::Stage> {
         Ok(match self {
             Self::Atlantic(inner) => AnyLayoutBridgeProver::Atlantic(inner.build()?),
             Self::Mock(inner) => AnyLayoutBridgeProver::Mock(inner.build()?),
         })
     }
 
-    fn statement_channel(
+    fn input_channel(
         self,
-        block_channel: Receiver<<Self::Prover as Prover>::Statement>,
+        block_channel: Receiver<<Self::Stage as PipelineStage>::Input>,
     ) -> Self {
         match self {
-            Self::Atlantic(inner) => Self::Atlantic(inner.statement_channel(block_channel)),
-            Self::Mock(inner) => Self::Mock(inner.statement_channel(block_channel)),
+            Self::Atlantic(inner) => Self::Atlantic(inner.input_channel(block_channel)),
+            Self::Mock(inner) => Self::Mock(inner.input_channel(block_channel)),
         }
     }
 
-    fn proof_channel(self, proof_channel: Sender<<Self::Prover as Prover>::BlockInfo>) -> Self {
+    fn output_channel(self, output_channel: Sender<<Self::Stage as PipelineStage>::Output>) -> Self {
         match self {
-            Self::Atlantic(inner) => Self::Atlantic(inner.proof_channel(proof_channel)),
-            Self::Mock(inner) => Self::Mock(inner.proof_channel(proof_channel)),
+            Self::Atlantic(inner) => Self::Atlantic(inner.output_channel(output_channel)),
+            Self::Mock(inner) => Self::Mock(inner.output_channel(output_channel)),
         }
     }
 }

--- a/bin/saya/src/main.rs
+++ b/bin/saya/src/main.rs
@@ -12,6 +12,9 @@ use sovereign::Sovereign;
 mod persistent;
 use persistent::Persistent;
 
+mod persistent_tee;
+use persistent_tee::PersistentTee;
+
 mod sharding;
 use sharding::Sharding;
 
@@ -41,6 +44,9 @@ enum Subcommands {
     /// Run and manage Saya in persistent L3 mode where proofs are settled in a "base layer"
     /// network.
     Persistent(Persistent),
+    /// Run and manage Saya in persistent TEE mode where blocks are proved inside a trusted
+    /// execution environment and settled in a "base layer" network.
+    PersistentTee(PersistentTee),
     /// Run and manage Saya in sharding mode.
     Sharding(Sharding),
     /// Core contract utilities for deployment and management.
@@ -63,6 +69,7 @@ async fn main() -> Result<()> {
     match cli.command {
         Subcommands::Sovereign(cmd) => cmd.run().await,
         Subcommands::Persistent(cmd) => cmd.run().await,
+        Subcommands::PersistentTee(cmd) => cmd.run().await,
         Subcommands::Sharding(cmd) => cmd.run().await,
         Subcommands::CoreContract(cmd) => cmd.run().await,
         Subcommands::Celestia(cmd) => cmd.run().await,

--- a/bin/saya/src/persistent.rs
+++ b/bin/saya/src/persistent.rs
@@ -9,8 +9,8 @@ use saya_core::{
     },
     orchestrator::PersistentOrchestratorBuilder,
     prover::{
-        AtlanticLayoutBridgeProverBuilder, AtlanticSnosProverBuilder,
-        MockLayoutBridgeProverBuilder, RecursiveProverBuilder, SnosPieGeneratorBuilder,
+        AtlanticLayoutBridgeProverBuilder, AtlanticSnosProverBuilder, BlockOrdererBuilder,
+        MockLayoutBridgeProverBuilder, PipelineChainBuilder, SnosPieGeneratorBuilder,
     },
     service::Daemon,
     settlement::PiltoverSettlementBackendBuilder,
@@ -154,7 +154,7 @@ impl Start {
 
         let mut atlantic_key: String = String::new();
         let db = SqliteDb::new(&saya_path).await?;
-        let layout_bridge_prover_builder =
+        let layout_bridge_pipeline_builder =
             match (self.mock_layout_bridge_program_hash, self.layout_bridge_program) {
                 // We don't need the `layout_bridge` program in this case but it's okay if it's given.
                 (Some(mock_layout_bridge_program_hash), _) => {
@@ -206,17 +206,20 @@ impl Start {
             ChainId::Other(rollup_chain_id),
         );
 
-        let prover_builder = RecursiveProverBuilder::new(
-            pie_gen_builder,
-            RecursiveProverBuilder::new(
-                AtlanticSnosProverBuilder::new(
-                    atlantic_key,
-                    self.mock_snos_from_pie,
-                    db.clone(),
-                    snos_worker_count,
+        let pipeline_builder = PipelineChainBuilder::new(
+            PipelineChainBuilder::new(
+                pie_gen_builder,
+                PipelineChainBuilder::new(
+                    AtlanticSnosProverBuilder::new(
+                        atlantic_key,
+                        self.mock_snos_from_pie,
+                        db.clone(),
+                        snos_worker_count,
+                    ),
+                    layout_bridge_pipeline_builder,
                 ),
-                layout_bridge_prover_builder,
             ),
+            BlockOrdererBuilder::new(),
         );
 
         let da_builder = if let (Some(celestia_rpc), Some(celestia_token)) =
@@ -260,7 +263,7 @@ impl Start {
 
         let orchestrator = PersistentOrchestratorBuilder::new(
             block_ingestor_builder,
-            prover_builder,
+            pipeline_builder,
             da_builder,
             settlement_builder,
         )

--- a/bin/saya/src/persistent.rs
+++ b/bin/saya/src/persistent.rs
@@ -10,7 +10,7 @@ use saya_core::{
     orchestrator::PersistentOrchestratorBuilder,
     prover::{
         AtlanticLayoutBridgeProverBuilder, AtlanticSnosProverBuilder,
-        MockLayoutBridgeProverBuilder, RecursiveProverBuilder,
+        MockLayoutBridgeProverBuilder, RecursiveProverBuilder, SnosPieGeneratorBuilder,
     },
     service::Daemon,
     settlement::PiltoverSettlementBackendBuilder,
@@ -189,6 +189,12 @@ impl Start {
         // TODO: make impls of these providers configurable
 
         let block_ingestor_builder = PollingBlockIngestorBuilder::new(
+            self.rollup_rpc.clone(),
+            db.clone(),
+            ingestor_worker_count,
+        );
+
+        let pie_gen_builder = SnosPieGeneratorBuilder::new(
             self.rollup_rpc,
             db.clone(),
             ingestor_worker_count,
@@ -201,13 +207,16 @@ impl Start {
         );
 
         let prover_builder = RecursiveProverBuilder::new(
-            AtlanticSnosProverBuilder::new(
-                atlantic_key,
-                self.mock_snos_from_pie,
-                db.clone(),
-                snos_worker_count,
+            pie_gen_builder,
+            RecursiveProverBuilder::new(
+                AtlanticSnosProverBuilder::new(
+                    atlantic_key,
+                    self.mock_snos_from_pie,
+                    db.clone(),
+                    snos_worker_count,
+                ),
+                layout_bridge_prover_builder,
             ),
-            layout_bridge_prover_builder,
         );
 
         let da_builder = if let (Some(celestia_rpc), Some(celestia_token)) =

--- a/bin/saya/src/persistent_tee.rs
+++ b/bin/saya/src/persistent_tee.rs
@@ -3,11 +3,8 @@ use std::{path::PathBuf, time::Duration};
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use saya_core::{
-    block_ingestor::PollingBlockIngestorBuilder,
-    orchestrator::PersistentTeeOrchestratorBuilder,
-    service::Daemon,
-    settlement::PiltoverSettlementBackendBuilder,
-    storage::SqliteDb,
+    block_ingestor::PollingBlockIngestorBuilder, orchestrator::PersistentTeeOrchestratorBuilder,
+    service::Daemon, settlement::PiltoverSettlementBackendBuilder, storage::SqliteDb,
 };
 use starknet_types_core::felt::Felt;
 use url::Url;
@@ -71,11 +68,8 @@ impl Start {
 
         let db = SqliteDb::new(&saya_path).await?;
 
-        let block_ingestor_builder = PollingBlockIngestorBuilder::new(
-            self.rollup_rpc,
-            db.clone(),
-            self.ingestor_workers,
-        );
+        let block_ingestor_builder =
+            PollingBlockIngestorBuilder::new(self.rollup_rpc, db.clone(), self.ingestor_workers);
 
         // In TEE mode the proof is attested inside the enclave; on-chain fact registration via
         // the integrity verifier is not required.

--- a/bin/saya/src/persistent_tee.rs
+++ b/bin/saya/src/persistent_tee.rs
@@ -1,0 +1,120 @@
+use std::{path::PathBuf, time::Duration};
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use saya_core::{
+    block_ingestor::PollingBlockIngestorBuilder,
+    orchestrator::PersistentTeeOrchestratorBuilder,
+    service::Daemon,
+    settlement::PiltoverSettlementBackendBuilder,
+    storage::SqliteDb,
+};
+use starknet_types_core::felt::Felt;
+use url::Url;
+
+use crate::common::SAYA_DB_PATH;
+
+/// 10 seconds.
+const GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Parser)]
+pub struct PersistentTee {
+    #[clap(subcommand)]
+    command: Subcommands,
+}
+
+#[derive(Debug, Subcommand)]
+enum Subcommands {
+    /// Start Saya in persistent TEE mode.
+    Start(Start),
+}
+
+#[derive(Debug, Parser, Clone)]
+struct Start {
+    /// Rollup network Starknet JSON-RPC URL (v0.7.1)
+    #[clap(long, env)]
+    rollup_rpc: Url,
+    /// Settlement network Starknet JSON-RPC URL (v0.7.1)
+    #[clap(long, env)]
+    settlement_rpc: Url,
+    /// Settlement network piltover contract address
+    #[clap(long, env)]
+    settlement_piltover_address: Felt,
+    /// Settlement network account contract address
+    #[clap(long, env)]
+    settlement_account_address: Felt,
+    /// Settlement network account private key
+    #[clap(long, env)]
+    settlement_account_private_key: Felt,
+    /// Path to the database directory
+    #[clap(long, env)]
+    db_dir: Option<PathBuf>,
+    /// Number of block ingestor workers
+    #[clap(long, env, default_value_t = 4)]
+    ingestor_workers: usize,
+}
+
+impl PersistentTee {
+    pub async fn run(self) -> Result<()> {
+        match self.command {
+            Subcommands::Start(start) => start.run().await,
+        }
+    }
+}
+
+impl Start {
+    pub async fn run(self) -> Result<()> {
+        let saya_path = self
+            .db_dir
+            .map(|db_dir| format!("{}/{}", db_dir.display(), SAYA_DB_PATH))
+            .unwrap_or_else(|| SAYA_DB_PATH.to_string());
+
+        let db = SqliteDb::new(&saya_path).await?;
+
+        let block_ingestor_builder = PollingBlockIngestorBuilder::new(
+            self.rollup_rpc,
+            db.clone(),
+            self.ingestor_workers,
+        );
+
+        // In TEE mode the proof is attested inside the enclave; on-chain fact registration via
+        // the integrity verifier is not required.
+        let settlement_builder = PiltoverSettlementBackendBuilder::new(
+            self.settlement_rpc,
+            self.settlement_piltover_address,
+            self.settlement_account_address,
+            self.settlement_account_private_key,
+            db.clone(),
+        )
+        .skip_fact_registration(true);
+
+        let orchestrator =
+            PersistentTeeOrchestratorBuilder::new(block_ingestor_builder, settlement_builder)
+                .build()
+                .await?;
+
+        let orchestrator_shutdown = orchestrator.shutdown_handle();
+        orchestrator.start();
+
+        let mut sigterm_handle =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+        let ctrl_c_handle = tokio::signal::ctrl_c();
+
+        tokio::select! {
+            _ = sigterm_handle.recv() => {},
+            _ = ctrl_c_handle => {},
+            _ = orchestrator_shutdown.finished() => {},
+        }
+
+        // Graceful shutdown
+        orchestrator_shutdown.shutdown();
+        tokio::select! {
+            _ = tokio::time::sleep(GRACEFUL_SHUTDOWN_TIMEOUT) => {
+                Err(anyhow::anyhow!("timeout waiting for graceful shutdown"))
+            },
+            _ = orchestrator_shutdown.finished() => {
+                Ok(())
+            },
+        }
+    }
+}

--- a/bin/saya/src/sovereign.rs
+++ b/bin/saya/src/sovereign.rs
@@ -6,7 +6,10 @@ use saya_core::{
     block_ingestor::PollingBlockIngestorBuilder,
     data_availability::CelestiaDataAvailabilityBackendBuilder,
     orchestrator::{Genesis, SovereignOrchestratorBuilder},
-    prover::{AtlanticSnosProverBuilder, BlockOrdererBuilder, PipelineChainBuilder, SnosPieGeneratorBuilder},
+    prover::{
+        AtlanticSnosProverBuilder, BlockOrdererBuilder, PipelineChainBuilder,
+        SnosPieGeneratorBuilder,
+    },
     service::Daemon,
     storage::{InMemoryStorageBackend, SqliteDb},
     ChainId, OsHintsConfiguration,

--- a/bin/saya/src/sovereign.rs
+++ b/bin/saya/src/sovereign.rs
@@ -6,7 +6,7 @@ use saya_core::{
     block_ingestor::PollingBlockIngestorBuilder,
     data_availability::CelestiaDataAvailabilityBackendBuilder,
     orchestrator::{Genesis, SovereignOrchestratorBuilder},
-    prover::{AtlanticSnosProverBuilder, RecursiveProverBuilder, SnosPieGeneratorBuilder},
+    prover::{AtlanticSnosProverBuilder, BlockOrdererBuilder, PipelineChainBuilder, SnosPieGeneratorBuilder},
     service::Daemon,
     storage::{InMemoryStorageBackend, SqliteDb},
     ChainId, OsHintsConfiguration,
@@ -133,14 +133,17 @@ impl Start {
             ChainId::Other(chain_id),
         );
 
-        let prover_builder = RecursiveProverBuilder::new(
-            pie_gen_builder,
-            AtlanticSnosProverBuilder::new(
-                self.atlantic_key,
-                self.mock_snos_from_pie,
-                db.clone(),
-                snos_worker_count,
+        let pipeline_builder = PipelineChainBuilder::new(
+            PipelineChainBuilder::new(
+                pie_gen_builder,
+                AtlanticSnosProverBuilder::new(
+                    self.atlantic_key,
+                    self.mock_snos_from_pie,
+                    db.clone(),
+                    snos_worker_count,
+                ),
             ),
+            BlockOrdererBuilder::new(),
         );
         let da_builder = CelestiaDataAvailabilityBackendBuilder::new(
             self.celestia_rpc,
@@ -152,7 +155,7 @@ impl Start {
 
         let orchestrator = SovereignOrchestratorBuilder::new(
             block_ingestor_builder,
-            prover_builder,
+            pipeline_builder,
             da_builder,
             storage,
             self.genesis.into(),

--- a/bin/saya/src/sovereign.rs
+++ b/bin/saya/src/sovereign.rs
@@ -6,7 +6,7 @@ use saya_core::{
     block_ingestor::PollingBlockIngestorBuilder,
     data_availability::CelestiaDataAvailabilityBackendBuilder,
     orchestrator::{Genesis, SovereignOrchestratorBuilder},
-    prover::AtlanticSnosProverBuilder,
+    prover::{AtlanticSnosProverBuilder, RecursiveProverBuilder, SnosPieGeneratorBuilder},
     service::Daemon,
     storage::{InMemoryStorageBackend, SqliteDb},
     ChainId, OsHintsConfiguration,
@@ -116,6 +116,12 @@ impl Start {
         )?;
 
         let block_ingestor_builder = PollingBlockIngestorBuilder::new(
+            self.starknet_rpc.clone(),
+            db.clone(),
+            ingestor_worker_count,
+        );
+
+        let pie_gen_builder = SnosPieGeneratorBuilder::new(
             self.starknet_rpc,
             db.clone(),
             ingestor_worker_count,
@@ -127,11 +133,14 @@ impl Start {
             ChainId::Other(chain_id),
         );
 
-        let prover_builder = AtlanticSnosProverBuilder::new(
-            self.atlantic_key,
-            self.mock_snos_from_pie,
-            db.clone(),
-            snos_worker_count,
+        let prover_builder = RecursiveProverBuilder::new(
+            pie_gen_builder,
+            AtlanticSnosProverBuilder::new(
+                self.atlantic_key,
+                self.mock_snos_from_pie,
+                db.clone(),
+                snos_worker_count,
+            ),
         );
         let da_builder = CelestiaDataAvailabilityBackendBuilder::new(
             self.celestia_rpc,

--- a/saya/core/src/block_ingestor/polling.rs
+++ b/saya/core/src/block_ingestor/polling.rs
@@ -159,8 +159,7 @@ where
             match self.get_latest_block().await {
                 Some(latest_block) if latest_block >= self.current_block => {
                     if let Ok(mut failed_blocks) = self.db.get_failed_blocks().await {
-                        let block_ids: Vec<u32> =
-                            failed_blocks.iter().map(|(id, _)| *id).collect();
+                        let block_ids: Vec<u32> = failed_blocks.iter().map(|(id, _)| *id).collect();
                         for (block_id, _) in failed_blocks.drain(..) {
                             if task_tx.send(block_id as u64).await.is_err() {
                                 return;

--- a/saya/core/src/block_ingestor/polling.rs
+++ b/saya/core/src/block_ingestor/polling.rs
@@ -1,17 +1,11 @@
 use std::{sync::Arc, time::Duration};
 
 use anyhow::Result;
-use cairo_vm::vm::runners::cairo_pie::CairoPie;
-use generate_pie::{
-    generate_pie,
-    types::{ChainConfig, OsHintsConfiguration},
-};
-use log::{debug, error, info, trace};
+use log::{debug, error, trace};
 use starknet::{
     core::types::BlockId,
     providers::{jsonrpc::HttpTransport, JsonRpcClient, Provider},
 };
-use starknet_api::{contract_address, core::ChainId};
 use tokio::{
     sync::{
         mpsc::{self, Sender},
@@ -24,17 +18,24 @@ use url::Url;
 
 use crate::{
     block_ingestor::{BlockInfo, BlockIngestor, BlockIngestorBuilder},
-    prover::compress_pie,
     service::{Daemon, FinishHandle, ShutdownHandle},
-    storage::{BlockStatus, PersistantStorage, Step},
+    storage::{BlockStatus, PersistantStorage},
 };
 
 const BLOCK_CHECK_INTERVAL: Duration = Duration::from_secs(5);
 const TASK_BUFFER_SIZE: usize = 4;
 const MAX_RETRIES: usize = 3;
-const KATANA_DEFAULT_TOKEN_ADDRESS: &str =
-    "0x2e7442625bab778683501c0eadbc1ea17b3535da040a12ac7d281066e915eea";
+
 /// A block ingestor which collects new blocks by polling a Starknet RPC endpoint.
+///
+/// Responsibilities:
+/// - Track the current block and advance it as the chain progresses.
+/// - Re-queue blocks that previously failed.
+/// - Fetch the `StateUpdate` for each block and store it in the DB.
+/// - Emit `BlockInfo { status: Mined }` downstream for further processing.
+///
+/// PIE generation is intentionally **not** done here. It is the responsibility
+/// of the next pipeline stage (e.g. `SnosPieGenerator`).
 #[derive(Debug)]
 pub struct PollingBlockIngestor<DB> {
     rpc_url: Url,
@@ -43,8 +44,6 @@ pub struct PollingBlockIngestor<DB> {
     finish_handle: FinishHandle,
     db: DB,
     workers_count: usize,
-    chain_id: ChainId,
-    os_hints_config: OsHintsConfiguration,
 }
 
 #[derive(Debug)]
@@ -54,15 +53,12 @@ pub struct PollingBlockIngestorBuilder<DB> {
     channel: Option<Sender<BlockInfo>>,
     db: DB,
     workers_count: usize,
-    chain_id: ChainId,
-    os_hints_config: OsHintsConfiguration,
 }
 
 impl<DB> PollingBlockIngestor<DB>
 where
     DB: PersistantStorage + Send + Sync + Clone + 'static,
 {
-    /// Fetches the latest block number from the StarkNet RPC.
     async fn get_latest_block(&self) -> Option<u64> {
         let provider = JsonRpcClient::new(HttpTransport::new(self.rpc_url.clone()));
 
@@ -83,21 +79,19 @@ where
         }
     }
 
-    /// Worker function: proves a block and sends the result.
+    /// Worker function: fetches the state update for a block and emits `BlockInfo { status: Mined }`.
     async fn worker(
         task_rx: Arc<Mutex<mpsc::Receiver<u64>>>,
         finish_handle: FinishHandle,
         rpc_url: Url,
         channel: mpsc::Sender<BlockInfo>,
         db: DB,
-        os_hints_config: OsHintsConfiguration,
-        chain_id: ChainId,
     ) where
         DB: PersistantStorage + Send + Sync + 'static,
     {
         loop {
-            let block_number = if let Some(block_number) = task_rx.lock().await.recv().await {
-                block_number
+            let block_number = if let Some(n) = task_rx.lock().await.recv().await {
+                n
             } else {
                 break;
             };
@@ -109,15 +103,14 @@ where
             db.initialize_block(block_number.try_into().unwrap())
                 .await
                 .unwrap();
+
             let state_update = &JsonRpcClient::new(HttpTransport::new(rpc_url.clone()))
                 .get_state_update(BlockId::Number(block_number))
                 .await
                 .unwrap();
+
             let state_update = match state_update {
-                starknet::core::types::MaybePreConfirmedStateUpdate::Update(state_update) => {
-                    state_update
-                }
-                //TODO: handle this case properly
+                starknet::core::types::MaybePreConfirmedStateUpdate::Update(u) => u,
                 starknet::core::types::MaybePreConfirmedStateUpdate::PreConfirmedUpdate(_) => {
                     panic!("PreConfirmedStateUpdate not supported")
                 }
@@ -127,70 +120,13 @@ where
                 .await
                 .unwrap();
 
-            match db
-                .get_pie(block_number.try_into().unwrap(), Step::Snos)
-                .await
-            {
-                Ok(pie_bytes) => match CairoPie::from_bytes(&pie_bytes) {
-                    Ok(_pie) => {
-                        let new_block = BlockInfo {
-                            number: block_number,
-                            status: BlockStatus::SnosPieGenerated,
-                            state_update: Some(state_update.clone()),
-                        };
-                        trace!(block_number; "Pie generated");
-
-                        if channel.send(new_block).await.is_err() {
-                            error!(block_number; "Failed to send block");
-                        }
-                        continue;
-                    }
-                    Err(err) => {
-                        error!(block_number,error:% = err; "Failed to parse pie")
-                    }
-                },
-                Err(err) => {
-                    // Not found in db, we continue
-                    // Should we log this error, as this is kinda intended to not found pie on first iteration?
-                    trace!( block_number, error:% =err; "Pie not found in db");
-                }
-            }
-
-            let pie_input = generate_pie::types::PieGenerationInput {
-                rpc_url: rpc_url.to_string(),
-                blocks: vec![block_number],
-                versioned_constants: None,
-                chain_config: ChainConfig {
-                    chain_id: chain_id.clone(),
-                    strk_fee_token_address: contract_address!(KATANA_DEFAULT_TOKEN_ADDRESS),
-                    is_l3: true,
-                    eth_fee_token_address: contract_address!(KATANA_DEFAULT_TOKEN_ADDRESS),
-                },
-                layout: cairo_vm::types::layout_name::LayoutName::all_cairo,
-                os_hints_config: os_hints_config.clone(),
-                output_path: None,
-            };
-
-            let pie = generate_pie(pie_input).await.unwrap().output.cairo_pie;
-
-            if finish_handle.is_shutdown_requested() {
-                break;
-            }
+            trace!(block_number; "Block mined, forwarding downstream");
 
             let new_block = BlockInfo {
                 number: block_number,
-                status: BlockStatus::SnosPieGenerated,
+                status: BlockStatus::Mined,
                 state_update: Some(state_update.clone()),
             };
-
-            let pie_bytes = compress_pie(pie.clone()).await.unwrap();
-            let block_number = block_number.try_into().unwrap();
-
-            db.add_pie(block_number, pie_bytes.clone(), Step::Snos)
-                .await
-                .unwrap();
-
-            info!(block_number; "Pie generated for block");
 
             if channel.send(new_block).await.is_err() {
                 error!(block_number; "Failed to send block");
@@ -199,23 +135,6 @@ where
     }
 
     /// Continuously fetches the latest available block and sends it to the worker queue.
-    ///
-    /// This loop ensures that blocks are processed sequentially while also handling previously
-    /// failed blocks. It will continue running until a shutdown request is received.
-    ///
-    /// # Process:
-    /// - Checks if the latest available block is greater than or equal to the current block.
-    /// - If there are failed blocks, retrieves them and sends them to the worker queue.
-    /// - Marks handled failed blocks in the database.
-    /// - Sends the current block to the worker queue and increments `current_block`.
-    /// - If the latest block is not yet available, it waits before rechecking.
-    ///
-    /// # Shutdown Handling:
-    /// - The loop will terminate if `self.finish_handle.is_shutdown_requested()` returns `true`.
-    /// - If sending to the worker queue (`task_tx.send()`) fails, the loop exits early.
-    ///
-    /// # Blocking Behavior:
-    /// - If no new block is available, it waits for `BLOCK_CHECK_INTERVAL` before retrying.
     async fn run(mut self) {
         let (task_tx, task_rx) = mpsc::channel(TASK_BUFFER_SIZE);
         let mut workers = Vec::new();
@@ -233,8 +152,6 @@ where
                 rpc_url,
                 channel,
                 self.db.clone(),
-                self.os_hints_config.clone(),
-                self.chain_id.clone(),
             )));
         }
 
@@ -242,7 +159,8 @@ where
             match self.get_latest_block().await {
                 Some(latest_block) if latest_block >= self.current_block => {
                     if let Ok(mut failed_blocks) = self.db.get_failed_blocks().await {
-                        let block_ids: Vec<u32> = failed_blocks.iter().map(|(id, _)| *id).collect();
+                        let block_ids: Vec<u32> =
+                            failed_blocks.iter().map(|(id, _)| *id).collect();
                         for (block_id, _) in failed_blocks.drain(..) {
                             if task_tx.send(block_id as u64).await.is_err() {
                                 return;
@@ -265,28 +183,20 @@ where
         }
 
         drop(task_tx);
-        futures_util::future::join_all(workers).await; // Wait for all workers
+        futures_util::future::join_all(workers).await;
         debug!("Graceful shutdown finished");
         self.finish_handle.finish();
     }
 }
 
 impl<DB> PollingBlockIngestorBuilder<DB> {
-    pub fn new(
-        rpc_url: Url,
-        db: DB,
-        workers_count: usize,
-        os_hints_config: OsHintsConfiguration,
-        chain_id: ChainId,
-    ) -> Self {
+    pub fn new(rpc_url: Url, db: DB, workers_count: usize) -> Self {
         Self {
             rpc_url,
             start_block: None,
             channel: None,
             db,
             workers_count,
-            chain_id,
-            os_hints_config,
         }
     }
 }
@@ -309,8 +219,6 @@ where
                 .ok_or_else(|| anyhow::anyhow!("`channel` not set"))?,
             finish_handle: FinishHandle::new(),
             workers_count: self.workers_count,
-            chain_id: self.chain_id,
-            os_hints_config: self.os_hints_config,
         })
     }
 

--- a/saya/core/src/orchestrator/mod.rs
+++ b/saya/core/src/orchestrator/mod.rs
@@ -4,6 +4,9 @@ pub use sovereign::{SovereignOrchestrator, SovereignOrchestratorBuilder};
 mod persistent;
 pub use persistent::{PersistentOrchestrator, PersistentOrchestratorBuilder};
 
+mod persistent_tee;
+pub use persistent_tee::{PersistentTeeOrchestrator, PersistentTeeOrchestratorBuilder};
+
 #[derive(Debug)]
 pub struct Genesis {
     /// Number or height of the first block that transforms the genesis state. This is usually `0`

--- a/saya/core/src/orchestrator/persistent.rs
+++ b/saya/core/src/orchestrator/persistent.rs
@@ -20,7 +20,7 @@ use crate::{
 const BLOCK_INGESTOR_BUFFER_SIZE: usize = 4;
 
 /// Size of the `StarkProof` channel.
-const PROOF_BUFFER_SIZE: usize = 4;
+const OUTPUT_BUFFER_SIZE: usize = 4;
 
 /// Size of the `DataAvailabilityCursor` channel.
 const DA_CURSOR_BUFFER_SIZE: usize = 4;
@@ -94,7 +94,7 @@ where
     ) -> Result<PersistentOrchestrator<I::Ingestor, P::Stage, D::Backend, S::Backend>> {
         let (new_block_tx, new_block_rx) =
             tokio::sync::mpsc::channel::<BlockInfo>(BLOCK_INGESTOR_BUFFER_SIZE);
-        let (proof_tx, proof_rx) = tokio::sync::mpsc::channel::<BlockInfo>(PROOF_BUFFER_SIZE);
+        let (output_tx, output_rx) = tokio::sync::mpsc::channel::<BlockInfo>(OUTPUT_BUFFER_SIZE);
         let (da_cursor_tx, da_cursor_rx) =
             tokio::sync::mpsc::channel::<DataAvailabilityCursor<BlockInfo>>(DA_CURSOR_BUFFER_SIZE);
         let (settle_cursor_tx, settle_cursor_rx) =
@@ -128,13 +128,13 @@ where
             .pipeline_builder
             .start_block(start_block)
             .input_channel(new_block_rx)
-            .output_channel(proof_tx)
+            .output_channel(output_tx)
             .build()
             .unwrap();
 
         let da = self
             .da_builder
-            .proof_channel(proof_rx)
+            .proof_channel(output_rx)
             .cursor_channel(da_cursor_tx)
             .build()
             .unwrap();

--- a/saya/core/src/orchestrator/persistent.rs
+++ b/saya/core/src/orchestrator/persistent.rs
@@ -7,7 +7,7 @@ use crate::{
     data_availability::{
         DataAvailabilityBackend, DataAvailabilityBackendBuilder, DataAvailabilityCursor,
     },
-    prover::{Prover, ProverBuilder},
+    prover::{PipelineStage, PipelineStageBuilder},
     service::{Daemon, FinishHandle, ShutdownHandle},
     settlement::{SettlementBackend, SettlementBackendBuilder, SettlementCursor},
 };
@@ -41,7 +41,7 @@ const SETTLE_CURSOR_BUFFER_SIZE: usize = 4;
 pub struct PersistentOrchestrator<I, P, D, S> {
     cursor_channel: Receiver<SettlementCursor>,
     ingestor: I,
-    prover: P,
+    pipeline: P,
     da: D,
     settlement: S,
     finish_handle: FinishHandle,
@@ -50,7 +50,7 @@ pub struct PersistentOrchestrator<I, P, D, S> {
 #[derive(Debug)]
 pub struct PersistentOrchestratorBuilder<I, P, D, S> {
     ingestor_builder: I,
-    prover_builder: P,
+    pipeline_builder: P,
     da_builder: D,
     settlement_builder: S,
 }
@@ -58,7 +58,7 @@ pub struct PersistentOrchestratorBuilder<I, P, D, S> {
 struct PersistentOrchestratorState {
     cursor_channel: Receiver<SettlementCursor>,
     ingestor_handle: ShutdownHandle,
-    prover_handle: ShutdownHandle,
+    pipeline_handle: ShutdownHandle,
     da_handle: ShutdownHandle,
     settlement_handle: ShutdownHandle,
     finish_handle: FinishHandle,
@@ -67,13 +67,13 @@ struct PersistentOrchestratorState {
 impl<I, P, D, S> PersistentOrchestratorBuilder<I, P, D, S> {
     pub fn new(
         ingestor_builder: I,
-        prover_builder: P,
+        pipeline_builder: P,
         da_builder: D,
         settlement_builder: S,
     ) -> Self {
         Self {
             ingestor_builder,
-            prover_builder,
+            pipeline_builder,
             da_builder,
             settlement_builder,
         }
@@ -83,15 +83,15 @@ impl<I, P, D, S> PersistentOrchestratorBuilder<I, P, D, S> {
 impl<I, P, PV, D, DB, S> PersistentOrchestratorBuilder<I, P, D, S>
 where
     I: BlockIngestorBuilder + Send,
-    P: ProverBuilder<Prover = PV> + Send,
-    PV: Prover<Statement = BlockInfo, BlockInfo = BlockInfo>,
+    P: PipelineStageBuilder<Stage = PV> + Send,
+    PV: PipelineStage<Input = BlockInfo, Output = BlockInfo>,
     D: DataAvailabilityBackendBuilder<Backend = DB> + Send,
     DB: DataAvailabilityBackend<Payload = BlockInfo>,
     S: SettlementBackendBuilder + Send,
 {
     pub async fn build(
         self,
-    ) -> Result<PersistentOrchestrator<I::Ingestor, P::Prover, D::Backend, S::Backend>> {
+    ) -> Result<PersistentOrchestrator<I::Ingestor, P::Stage, D::Backend, S::Backend>> {
         let (new_block_tx, new_block_rx) =
             tokio::sync::mpsc::channel::<BlockInfo>(BLOCK_INGESTOR_BUFFER_SIZE);
         let (proof_tx, proof_rx) = tokio::sync::mpsc::channel::<BlockInfo>(PROOF_BUFFER_SIZE);
@@ -124,10 +124,11 @@ where
             .build()
             .unwrap();
 
-        let prover = self
-            .prover_builder
-            .statement_channel(new_block_rx)
-            .proof_channel(proof_tx)
+        let pipeline = self
+            .pipeline_builder
+            .start_block(start_block)
+            .input_channel(new_block_rx)
+            .output_channel(proof_tx)
             .build()
             .unwrap();
 
@@ -141,7 +142,7 @@ where
         Ok(PersistentOrchestrator {
             cursor_channel: settle_cursor_rx,
             ingestor,
-            prover,
+            pipeline,
             da,
             settlement,
             finish_handle: FinishHandle::new(),
@@ -171,14 +172,14 @@ impl PersistentOrchestratorState {
 
         // Request graceful shutdown for all descendant services
         self.ingestor_handle.shutdown();
-        self.prover_handle.shutdown();
+        self.pipeline_handle.shutdown();
         self.da_handle.shutdown();
         self.settlement_handle.shutdown();
 
         // Wait for all descendant services to finish graceful shutdown
         futures_util::future::join_all([
             self.ingestor_handle.finished(),
-            self.prover_handle.finished(),
+            self.pipeline_handle.finished(),
             self.da_handle.finished(),
             self.settlement_handle.finished(),
         ])
@@ -192,7 +193,7 @@ impl PersistentOrchestratorState {
 impl<I, P, D, S> Daemon for PersistentOrchestrator<I, P, D, S>
 where
     I: BlockIngestor + Send,
-    P: Prover + Send,
+    P: PipelineStage + Send,
     D: DataAvailabilityBackend + Send,
     S: SettlementBackend + Send,
 {
@@ -204,14 +205,14 @@ where
         let state = PersistentOrchestratorState {
             cursor_channel: self.cursor_channel,
             ingestor_handle: self.ingestor.shutdown_handle(),
-            prover_handle: self.prover.shutdown_handle(),
+            pipeline_handle: self.pipeline.shutdown_handle(),
             da_handle: self.da.shutdown_handle(),
             settlement_handle: self.settlement.shutdown_handle(),
             finish_handle: self.finish_handle,
         };
 
         self.ingestor.start();
-        self.prover.start();
+        self.pipeline.start();
         self.da.start();
         self.settlement.start();
 

--- a/saya/core/src/orchestrator/persistent_tee.rs
+++ b/saya/core/src/orchestrator/persistent_tee.rs
@@ -5,12 +5,16 @@ use tokio::sync::mpsc::Receiver;
 use crate::{
     block_ingestor::{BlockInfo, BlockIngestor, BlockIngestorBuilder},
     data_availability::DataAvailabilityCursor,
+    prover::{BlockOrderer, BlockOrdererBuilder, PipelineStageBuilder},
     service::{Daemon, FinishHandle, ShutdownHandle},
     settlement::{SettlementBackend, SettlementBackendBuilder, SettlementCursor},
 };
 
-/// Size of the `BlockInfo` channel between ingestor and the bridge task.
+/// Size of the `BlockInfo` channel between ingestor and the orderer.
 const BLOCK_INGESTOR_BUFFER_SIZE: usize = 4;
+
+/// Size of the `BlockInfo` channel between orderer and the bridge task.
+const ORDERER_BUFFER_SIZE: usize = 4;
 
 /// Size of the `DataAvailabilityCursor` channel fed into settlement.
 const DA_CURSOR_BUFFER_SIZE: usize = 4;
@@ -34,6 +38,7 @@ const SETTLE_CURSOR_BUFFER_SIZE: usize = 4;
 pub struct PersistentTeeOrchestrator<I, S> {
     cursor_channel: Receiver<SettlementCursor>,
     ingestor: I,
+    orderer: BlockOrderer<BlockInfo>,
     settlement: S,
     finish_handle: FinishHandle,
 }
@@ -47,6 +52,7 @@ pub struct PersistentTeeOrchestratorBuilder<I, S> {
 struct PersistentTeeOrchestratorState {
     cursor_channel: Receiver<SettlementCursor>,
     ingestor_handle: ShutdownHandle,
+    orderer_handle: ShutdownHandle,
     settlement_handle: ShutdownHandle,
     finish_handle: FinishHandle,
 }
@@ -63,8 +69,10 @@ where
     S: SettlementBackendBuilder + Send,
 {
     pub async fn build(self) -> Result<PersistentTeeOrchestrator<I::Ingestor, S::Backend>> {
-        let (new_block_tx, mut new_block_rx) =
+        let (new_block_tx, new_block_rx) =
             tokio::sync::mpsc::channel::<BlockInfo>(BLOCK_INGESTOR_BUFFER_SIZE);
+        let (ordered_tx, mut ordered_rx) =
+            tokio::sync::mpsc::channel::<BlockInfo>(ORDERER_BUFFER_SIZE);
         let (da_cursor_tx, da_cursor_rx) =
             tokio::sync::mpsc::channel::<DataAvailabilityCursor<BlockInfo>>(DA_CURSOR_BUFFER_SIZE);
         let (settle_cursor_tx, settle_cursor_rx) =
@@ -90,10 +98,16 @@ where
             .build()
             .unwrap();
 
-        // Adapter task: wraps each `BlockInfo` in a `DataAvailabilityCursor` with no DA pointer
-        // so the settlement backend can remain unaware of the TEE-specific flow.
+        let orderer = BlockOrdererBuilder::new()
+            .start_block(start_block)
+            .input_channel(new_block_rx)
+            .output_channel(ordered_tx)
+            .build()?;
+
+        // Adapter task: wraps each in-order `BlockInfo` in a `DataAvailabilityCursor` with no DA
+        // pointer so the settlement backend can remain unaware of the TEE-specific flow.
         tokio::spawn(async move {
-            while let Some(block_info) = new_block_rx.recv().await {
+            while let Some(block_info) = ordered_rx.recv().await {
                 let cursor = DataAvailabilityCursor {
                     block_number: block_info.number,
                     pointer: None,
@@ -108,6 +122,7 @@ where
         Ok(PersistentTeeOrchestrator {
             cursor_channel: settle_cursor_rx,
             ingestor,
+            orderer,
             settlement,
             finish_handle: FinishHandle::new(),
         })
@@ -135,11 +150,13 @@ impl PersistentTeeOrchestratorState {
 
         // Request graceful shutdown for all descendant services.
         self.ingestor_handle.shutdown();
+        self.orderer_handle.shutdown();
         self.settlement_handle.shutdown();
 
         // Wait for all descendant services to finish.
         futures_util::future::join_all([
             self.ingestor_handle.finished(),
+            self.orderer_handle.finished(),
             self.settlement_handle.finished(),
         ])
         .await;
@@ -162,11 +179,13 @@ where
         let state = PersistentTeeOrchestratorState {
             cursor_channel: self.cursor_channel,
             ingestor_handle: self.ingestor.shutdown_handle(),
+            orderer_handle: self.orderer.shutdown_handle(),
             settlement_handle: self.settlement.shutdown_handle(),
             finish_handle: self.finish_handle,
         };
 
         self.ingestor.start();
+        self.orderer.start();
         self.settlement.start();
 
         tokio::spawn(state.run());

--- a/saya/core/src/orchestrator/persistent_tee.rs
+++ b/saya/core/src/orchestrator/persistent_tee.rs
@@ -59,7 +59,10 @@ struct PersistentTeeOrchestratorState {
 
 impl<I, S> PersistentTeeOrchestratorBuilder<I, S> {
     pub fn new(ingestor_builder: I, settlement_builder: S) -> Self {
-        Self { ingestor_builder, settlement_builder }
+        Self {
+            ingestor_builder,
+            settlement_builder,
+        }
     }
 }
 

--- a/saya/core/src/orchestrator/persistent_tee.rs
+++ b/saya/core/src/orchestrator/persistent_tee.rs
@@ -1,0 +1,174 @@
+use anyhow::Result;
+use log::{debug, info};
+use tokio::sync::mpsc::Receiver;
+
+use crate::{
+    block_ingestor::{BlockInfo, BlockIngestor, BlockIngestorBuilder},
+    data_availability::DataAvailabilityCursor,
+    service::{Daemon, FinishHandle, ShutdownHandle},
+    settlement::{SettlementBackend, SettlementBackendBuilder, SettlementCursor},
+};
+
+/// Size of the `BlockInfo` channel between ingestor and the bridge task.
+const BLOCK_INGESTOR_BUFFER_SIZE: usize = 4;
+
+/// Size of the `DataAvailabilityCursor` channel fed into settlement.
+const DA_CURSOR_BUFFER_SIZE: usize = 4;
+
+/// Size of the `SettlementCursor` channel.
+const SETTLE_CURSOR_BUFFER_SIZE: usize = 4;
+
+/// An orchestrator for running a rollup in TEE (Trusted Execution Environment) persistent mode.
+///
+/// In this mode the block is proved inside a secure enclave, so no external proving service or
+/// data availability layer is required. The orchestrator therefore only wires together two
+/// components:
+///
+/// 1. A **block ingestor** — polls the rollup RPC for new blocks and generates the Cairo PIE.
+/// 2. A **settlement backend** — submits the state-root transition on the base layer.
+///
+/// The ingestor output (`BlockInfo`) is forwarded to the settlement backend through an internal
+/// adapter task that wraps each item into a `DataAvailabilityCursor` with no DA pointer, keeping
+/// the settlement trait interface unchanged.
+#[derive(Debug)]
+pub struct PersistentTeeOrchestrator<I, S> {
+    cursor_channel: Receiver<SettlementCursor>,
+    ingestor: I,
+    settlement: S,
+    finish_handle: FinishHandle,
+}
+
+#[derive(Debug)]
+pub struct PersistentTeeOrchestratorBuilder<I, S> {
+    ingestor_builder: I,
+    settlement_builder: S,
+}
+
+struct PersistentTeeOrchestratorState {
+    cursor_channel: Receiver<SettlementCursor>,
+    ingestor_handle: ShutdownHandle,
+    settlement_handle: ShutdownHandle,
+    finish_handle: FinishHandle,
+}
+
+impl<I, S> PersistentTeeOrchestratorBuilder<I, S> {
+    pub fn new(ingestor_builder: I, settlement_builder: S) -> Self {
+        Self { ingestor_builder, settlement_builder }
+    }
+}
+
+impl<I, S> PersistentTeeOrchestratorBuilder<I, S>
+where
+    I: BlockIngestorBuilder + Send,
+    S: SettlementBackendBuilder + Send,
+{
+    pub async fn build(self) -> Result<PersistentTeeOrchestrator<I::Ingestor, S::Backend>> {
+        let (new_block_tx, mut new_block_rx) =
+            tokio::sync::mpsc::channel::<BlockInfo>(BLOCK_INGESTOR_BUFFER_SIZE);
+        let (da_cursor_tx, da_cursor_rx) =
+            tokio::sync::mpsc::channel::<DataAvailabilityCursor<BlockInfo>>(DA_CURSOR_BUFFER_SIZE);
+        let (settle_cursor_tx, settle_cursor_rx) =
+            tokio::sync::mpsc::channel::<SettlementCursor>(SETTLE_CURSOR_BUFFER_SIZE);
+
+        let settlement = self
+            .settlement_builder
+            .da_channel(da_cursor_rx)
+            .cursor_channel(settle_cursor_tx)
+            .build()
+            .await
+            .unwrap();
+
+        // Since the `Felt` type is wrapping (`Felt::MAX + 1 = 0`), there is no
+        // need for a special case for the genesis block, and `+1` works as expected.
+        let start_block = settlement.get_block_number().await? + 1;
+        let start_block: u64 = start_block.try_into()?;
+
+        let ingestor = self
+            .ingestor_builder
+            .start_block(start_block)
+            .channel(new_block_tx)
+            .build()
+            .unwrap();
+
+        // Adapter task: wraps each `BlockInfo` in a `DataAvailabilityCursor` with no DA pointer
+        // so the settlement backend can remain unaware of the TEE-specific flow.
+        tokio::spawn(async move {
+            while let Some(block_info) = new_block_rx.recv().await {
+                let cursor = DataAvailabilityCursor {
+                    block_number: block_info.number,
+                    pointer: None,
+                    full_payload: block_info,
+                };
+                if da_cursor_tx.send(cursor).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        Ok(PersistentTeeOrchestrator {
+            cursor_channel: settle_cursor_rx,
+            ingestor,
+            settlement,
+            finish_handle: FinishHandle::new(),
+        })
+    }
+}
+
+impl PersistentTeeOrchestratorState {
+    async fn run(mut self) {
+        loop {
+            // TODO: handle unexpected exit of descendant services
+            let new_cursor = tokio::select! {
+                _ = self.finish_handle.shutdown_requested() => break,
+                new_cursor = self.cursor_channel.recv() => new_cursor,
+            };
+
+            // The settlement backend won't drop the sender while running.
+            let new_cursor = new_cursor.unwrap();
+
+            info!(
+                block_number = new_cursor.block_number,
+                transaction_hash:% = format!("{:#064x}", new_cursor.transaction_hash);
+                "Chain advanced to new block"
+            );
+        }
+
+        // Request graceful shutdown for all descendant services.
+        self.ingestor_handle.shutdown();
+        self.settlement_handle.shutdown();
+
+        // Wait for all descendant services to finish.
+        futures_util::future::join_all([
+            self.ingestor_handle.finished(),
+            self.settlement_handle.finished(),
+        ])
+        .await;
+
+        debug!("Graceful shutdown finished");
+        self.finish_handle.finish();
+    }
+}
+
+impl<I, S> Daemon for PersistentTeeOrchestrator<I, S>
+where
+    I: BlockIngestor + Send,
+    S: SettlementBackend + Send,
+{
+    fn shutdown_handle(&self) -> ShutdownHandle {
+        self.finish_handle.shutdown_handle()
+    }
+
+    fn start(self) {
+        let state = PersistentTeeOrchestratorState {
+            cursor_channel: self.cursor_channel,
+            ingestor_handle: self.ingestor.shutdown_handle(),
+            settlement_handle: self.settlement.shutdown_handle(),
+            finish_handle: self.finish_handle,
+        };
+
+        self.ingestor.start();
+        self.settlement.start();
+
+        tokio::spawn(state.run());
+    }
+}

--- a/saya/core/src/orchestrator/sovereign.rs
+++ b/saya/core/src/orchestrator/sovereign.rs
@@ -10,7 +10,7 @@ use crate::{
         DataAvailabilityPointer,
     },
     orchestrator::Genesis,
-    prover::{Prover, ProverBuilder, SnosProof},
+    prover::{PipelineStage, PipelineStageBuilder, SnosProof},
     service::{Daemon, FinishHandle, ShutdownHandle},
     storage::{BlockWithDa, ChainHead, StorageBackend},
 };
@@ -37,7 +37,7 @@ const CURSOR_BUFFER_SIZE: usize = 1;
 pub struct SovereignOrchestrator<I, P, D, S> {
     cursor_channel: Receiver<DataAvailabilityCursor<SnosProof<StarkProof>>>,
     ingestor: I,
-    prover: P,
+    pipeline: P,
     da: D,
     storage: S,
     finish_handle: FinishHandle,
@@ -46,7 +46,7 @@ pub struct SovereignOrchestrator<I, P, D, S> {
 #[derive(Debug)]
 pub struct SovereignOrchestratorBuilder<I, P, D, S> {
     ingestor_builder: I,
-    prover_builder: P,
+    pipeline_builder: P,
     da_builder: D,
     storage: S,
     genesis: Option<Genesis>,
@@ -56,7 +56,7 @@ struct SovereignOrchestratorState<S> {
     cursor_channel: Receiver<DataAvailabilityCursor<SnosProof<StarkProof>>>,
     storage: S,
     ingestor_handle: ShutdownHandle,
-    prover_handle: ShutdownHandle,
+    pipeline_handle: ShutdownHandle,
     da_handle: ShutdownHandle,
     finish_handle: FinishHandle,
 }
@@ -64,14 +64,14 @@ struct SovereignOrchestratorState<S> {
 impl<I, P, D, S> SovereignOrchestratorBuilder<I, P, D, S> {
     pub fn new(
         ingestor_builder: I,
-        prover_builder: P,
+        pipeline_builder: P,
         da_builder: D,
         storage: S,
         genesis: Option<Genesis>,
     ) -> Self {
         Self {
             ingestor_builder,
-            prover_builder,
+            pipeline_builder,
             da_builder,
             storage,
             genesis,
@@ -82,15 +82,15 @@ impl<I, P, D, S> SovereignOrchestratorBuilder<I, P, D, S> {
 impl<I, P, PV, D, DB, S> SovereignOrchestratorBuilder<I, P, D, S>
 where
     I: BlockIngestorBuilder + Send,
-    P: ProverBuilder<Prover = PV> + Send,
-    PV: Prover<Statement = BlockInfo, BlockInfo = SnosProof<StarkProof>>,
+    P: PipelineStageBuilder<Stage = PV> + Send,
+    PV: PipelineStage<Input = BlockInfo, Output = SnosProof<StarkProof>>,
     D: DataAvailabilityBackendBuilder<Backend = DB> + Send,
     DB: DataAvailabilityBackend<Payload = SnosProof<StarkProof>>,
     S: StorageBackend,
 {
     pub async fn build(
         self,
-    ) -> Result<SovereignOrchestrator<I::Ingestor, P::Prover, D::Backend, S>> {
+    ) -> Result<SovereignOrchestrator<I::Ingestor, P::Stage, D::Backend, S>> {
         let (new_block_tx, new_block_rx) =
             tokio::sync::mpsc::channel::<BlockInfo>(BLOCK_INGESTOR_BUFFER_SIZE);
         let (proof_tx, proof_rx) =
@@ -130,10 +130,11 @@ where
             .build()
             .unwrap();
 
-        let prover = self
-            .prover_builder
-            .statement_channel(new_block_rx)
-            .proof_channel(proof_tx)
+        let pipeline = self
+            .pipeline_builder
+            .start_block(start_block)
+            .input_channel(new_block_rx)
+            .output_channel(proof_tx)
             .build()
             .unwrap();
 
@@ -146,7 +147,7 @@ where
         Ok(SovereignOrchestrator {
             cursor_channel: cursor_rx,
             ingestor,
-            prover,
+            pipeline,
             da,
             storage: self.storage,
             finish_handle: FinishHandle::new(),
@@ -184,13 +185,13 @@ where
 
         // Request graceful shutdown for all descendant services
         self.ingestor_handle.shutdown();
-        self.prover_handle.shutdown();
+        self.pipeline_handle.shutdown();
         self.da_handle.shutdown();
 
         // Wait for all descendant services to finish graceful shutdown
         futures_util::future::join_all([
             self.ingestor_handle.finished(),
-            self.prover_handle.finished(),
+            self.pipeline_handle.finished(),
             self.da_handle.finished(),
         ])
         .await;
@@ -203,7 +204,7 @@ where
 impl<I, P, D, S> Daemon for SovereignOrchestrator<I, P, D, S>
 where
     I: BlockIngestor + Send,
-    P: Prover + Send,
+    P: PipelineStage + Send,
     D: DataAvailabilityBackend + Send,
     S: StorageBackend + Send + 'static,
 {
@@ -216,13 +217,13 @@ where
             cursor_channel: self.cursor_channel,
             storage: self.storage,
             ingestor_handle: self.ingestor.shutdown_handle(),
-            prover_handle: self.prover.shutdown_handle(),
+            pipeline_handle: self.pipeline.shutdown_handle(),
             da_handle: self.da.shutdown_handle(),
             finish_handle: self.finish_handle,
         };
 
         self.ingestor.start();
-        self.prover.start();
+        self.pipeline.start();
         self.da.start();
 
         tokio::spawn(state.run());

--- a/saya/core/src/orchestrator/sovereign.rs
+++ b/saya/core/src/orchestrator/sovereign.rs
@@ -23,7 +23,7 @@ use crate::{
 const BLOCK_INGESTOR_BUFFER_SIZE: usize = 1;
 
 /// Size of the `StarkProof` channel.
-const PROOF_BUFFER_SIZE: usize = 1;
+const OUTPUT_BUFFER_SIZE: usize = 1;
 
 /// Size of the `DataAvailabilityCursor` channel.
 const CURSOR_BUFFER_SIZE: usize = 1;
@@ -93,8 +93,8 @@ where
     ) -> Result<SovereignOrchestrator<I::Ingestor, P::Stage, D::Backend, S>> {
         let (new_block_tx, new_block_rx) =
             tokio::sync::mpsc::channel::<BlockInfo>(BLOCK_INGESTOR_BUFFER_SIZE);
-        let (proof_tx, proof_rx) =
-            tokio::sync::mpsc::channel::<SnosProof<StarkProof>>(PROOF_BUFFER_SIZE);
+        let (output_tx, output_rx) =
+            tokio::sync::mpsc::channel::<SnosProof<StarkProof>>(OUTPUT_BUFFER_SIZE);
         let (cursor_tx, cursor_rx) = tokio::sync::mpsc::channel::<
             DataAvailabilityCursor<SnosProof<StarkProof>>,
         >(CURSOR_BUFFER_SIZE);
@@ -134,12 +134,12 @@ where
             .pipeline_builder
             .start_block(start_block)
             .input_channel(new_block_rx)
-            .output_channel(proof_tx)
+            .output_channel(output_tx)
             .build()
             .unwrap();
 
         let da = da_builder
-            .proof_channel(proof_rx)
+            .proof_channel(output_rx)
             .cursor_channel(cursor_tx)
             .build()
             .unwrap();

--- a/saya/core/src/prover/atlantic/layout_bridge.rs
+++ b/saya/core/src/prover/atlantic/layout_bridge.rs
@@ -9,7 +9,7 @@ use crate::{
             snos::compress_pie,
         },
         error::ProverError,
-        Prover, ProverBuilder, SnosProof,
+        PipelineStage, PipelineStageBuilder, SnosProof,
     },
     service::{Daemon, FinishHandle, ShutdownHandle},
     storage::{PersistantStorage, Step},
@@ -27,8 +27,8 @@ use tokio::sync::{
 pub struct AtlanticLayoutBridgeProver<DB> {
     client: AtlanticClient,
     layout_bridge: Cow<'static, [u8]>,
-    statement_channel: Receiver<SnosProof<String>>,
-    proof_channel: Sender<BlockInfo>,
+    input_channel: Receiver<SnosProof<String>>,
+    output_channel: Sender<BlockInfo>,
     finish_handle: FinishHandle,
     db: DB,
     workers_count: usize,
@@ -38,8 +38,8 @@ pub struct AtlanticLayoutBridgeProver<DB> {
 pub struct AtlanticLayoutBridgeProverBuilder<DB> {
     api_key: String,
     layout_bridge: Cow<'static, [u8]>,
-    statement_channel: Option<Receiver<SnosProof<String>>>,
-    proof_channel: Option<Sender<BlockInfo>>,
+    input_channel: Option<Receiver<SnosProof<String>>>,
+    output_channel: Option<Sender<BlockInfo>>,
     db: DB,
     workers_count: usize,
 }
@@ -343,10 +343,10 @@ where
 
     async fn run(self) {
         let mut workers = Vec::new();
-        let task_rx = Arc::new(Mutex::new(self.statement_channel));
+        let task_rx = Arc::new(Mutex::new(self.input_channel));
         for _ in 0..self.workers_count {
             let worker_task_rx = task_rx.clone();
-            let task_tx = self.proof_channel.clone();
+            let task_tx = self.output_channel.clone();
             let client = self.client.clone();
             let layout_bridge = self.layout_bridge.clone();
             let finish_handle = self.finish_handle.clone();
@@ -375,53 +375,53 @@ impl<DB> AtlanticLayoutBridgeProverBuilder<DB> {
         Self {
             api_key,
             layout_bridge: layout_bridge.into(),
-            statement_channel: None,
-            proof_channel: None,
+            input_channel: None,
+            output_channel: None,
             db,
             workers_count,
         }
     }
 }
 
-impl<DB> ProverBuilder for AtlanticLayoutBridgeProverBuilder<DB>
+impl<DB> PipelineStageBuilder for AtlanticLayoutBridgeProverBuilder<DB>
 where
     DB: PersistantStorage + Send + Sync + Clone + 'static,
 {
-    type Prover = AtlanticLayoutBridgeProver<DB>;
+    type Stage = AtlanticLayoutBridgeProver<DB>;
 
-    fn build(self) -> Result<Self::Prover> {
+    fn build(self) -> Result<Self::Stage> {
         Ok(AtlanticLayoutBridgeProver {
             client: AtlanticClient::new(self.api_key),
             layout_bridge: self.layout_bridge,
-            statement_channel: self
-                .statement_channel
-                .ok_or_else(|| anyhow::anyhow!("`statement_channel` not set"))?,
-            proof_channel: self
-                .proof_channel
-                .ok_or_else(|| anyhow::anyhow!("`proof_channel` not set"))?,
+            input_channel: self
+                .input_channel
+                .ok_or_else(|| anyhow::anyhow!("`input_channel` not set"))?,
+            output_channel: self
+                .output_channel
+                .ok_or_else(|| anyhow::anyhow!("`output_channel` not set"))?,
             finish_handle: FinishHandle::new(),
             db: self.db,
             workers_count: self.workers_count,
         })
     }
 
-    fn statement_channel(mut self, statement_channel: Receiver<SnosProof<String>>) -> Self {
-        self.statement_channel = Some(statement_channel);
+    fn input_channel(mut self, input_channel: Receiver<SnosProof<String>>) -> Self {
+        self.input_channel = Some(input_channel);
         self
     }
 
-    fn proof_channel(mut self, proof_channel: Sender<BlockInfo>) -> Self {
-        self.proof_channel = Some(proof_channel);
+    fn output_channel(mut self, output_channel: Sender<BlockInfo>) -> Self {
+        self.output_channel = Some(output_channel);
         self
     }
 }
 
-impl<DB> Prover for AtlanticLayoutBridgeProver<DB>
+impl<DB> PipelineStage for AtlanticLayoutBridgeProver<DB>
 where
     DB: PersistantStorage + Send + Sync + Clone + 'static,
 {
-    type Statement = SnosProof<String>;
-    type BlockInfo = BlockInfo;
+    type Input = SnosProof<String>;
+    type Output = BlockInfo;
 }
 
 impl<DB> Daemon for AtlanticLayoutBridgeProver<DB>

--- a/saya/core/src/prover/atlantic/layout_bridge.rs
+++ b/saya/core/src/prover/atlantic/layout_bridge.rs
@@ -156,13 +156,13 @@ where
                     )
                     .await?;
 
-                    let new_proof = BlockInfo {
+                    let output = BlockInfo {
                         number: new_snos_proof.block_number,
                         status: crate::storage::BlockStatus::SnosProofGenerated,
                         state_update: Some(state_update.clone()),
                     };
 
-                    task_tx.send(new_proof).await.unwrap();
+                    task_tx.send(output).await.unwrap();
                     continue;
                 }
                 Err(_) => {
@@ -327,7 +327,7 @@ where
                 "Atlantic layout bridge proof generation finished",
             );
 
-            let new_proof = BlockInfo {
+            let output = BlockInfo {
                 number: new_snos_proof.block_number,
                 status: crate::storage::BlockStatus::SnosProofGenerated,
                 state_update: Some(state_update.clone()),
@@ -335,7 +335,7 @@ where
 
             tokio::select! {
                 _ = finish_handle.shutdown_requested() => break,
-                _ = task_tx.send(new_proof) => {},
+                _ = task_tx.send(output) => {},
             }
         }
         Ok(())

--- a/saya/core/src/prover/atlantic/snos.rs
+++ b/saya/core/src/prover/atlantic/snos.rs
@@ -22,7 +22,7 @@ use crate::{
             AtlanticProof,
         },
         error::ProverError,
-        Prover, ProverBuilder, SnosProof,
+        PipelineStage, PipelineStageBuilder, SnosProof,
     },
     service::{Daemon, FinishHandle, ShutdownHandle},
     storage::{PersistantStorage, Step},
@@ -33,8 +33,8 @@ use crate::{
 #[derive(Debug)]
 pub struct AtlanticSnosProver<P, DB> {
     client: AtlanticClient,
-    statement_channel: Receiver<BlockInfo>,
-    proof_channel: Sender<SnosProof<P>>,
+    input_channel: Receiver<BlockInfo>,
+    output_channel: Sender<SnosProof<P>>,
     finish_handle: FinishHandle,
     /// Whether to extract the output and compute the program hash from the PIE or use the one from the SHARP bootloader returned by the prover service.
     mock_snos_from_pie: bool,
@@ -45,8 +45,8 @@ pub struct AtlanticSnosProver<P, DB> {
 #[derive(Debug)]
 pub struct AtlanticSnosProverBuilder<P, DB> {
     api_key: String,
-    statement_channel: Option<Receiver<BlockInfo>>,
-    proof_channel: Option<Sender<SnosProof<P>>>,
+    input_channel: Option<Receiver<BlockInfo>>,
+    output_channel: Option<Sender<SnosProof<P>>>,
     mock_snos_from_pie: bool,
     db: DB,
     worker_count: usize,
@@ -249,9 +249,9 @@ where
 
     async fn run(self) {
         let mut workers = Vec::new();
-        let task_rx = Arc::new(Mutex::new(self.statement_channel));
+        let task_rx = Arc::new(Mutex::new(self.input_channel));
         for _ in 0..self.worker_count {
-            let worker_task_tx = self.proof_channel.clone();
+            let worker_task_tx = self.output_channel.clone();
             workers.push(task::spawn(Self::worker(
                 task_rx.clone(),
                 worker_task_tx,
@@ -297,8 +297,8 @@ impl<P, DB> AtlanticSnosProverBuilder<P, DB> {
     pub fn new(api_key: String, mock_snos_from_pie: bool, db: DB, worker_count: usize) -> Self {
         Self {
             api_key,
-            statement_channel: None,
-            proof_channel: None,
+            input_channel: None,
+            output_channel: None,
             mock_snos_from_pie,
             db,
             worker_count,
@@ -306,22 +306,22 @@ impl<P, DB> AtlanticSnosProverBuilder<P, DB> {
     }
 }
 
-impl<P, DB> ProverBuilder for AtlanticSnosProverBuilder<P, DB>
+impl<P, DB> PipelineStageBuilder for AtlanticSnosProverBuilder<P, DB>
 where
     P: AtlanticProof + Send + Sync + 'static,
     DB: PersistantStorage + Send + Sync + Clone + 'static,
 {
-    type Prover = AtlanticSnosProver<P, DB>;
+    type Stage = AtlanticSnosProver<P, DB>;
 
-    fn build(self) -> Result<Self::Prover> {
+    fn build(self) -> Result<Self::Stage> {
         Ok(AtlanticSnosProver {
             client: AtlanticClient::new(self.api_key),
-            statement_channel: self
-                .statement_channel
-                .ok_or_else(|| anyhow::anyhow!("`statement_channel` not set"))?,
-            proof_channel: self
-                .proof_channel
-                .ok_or_else(|| anyhow::anyhow!("`proof_channel` not set"))?,
+            input_channel: self
+                .input_channel
+                .ok_or_else(|| anyhow::anyhow!("`input_channel` not set"))?,
+            output_channel: self
+                .output_channel
+                .ok_or_else(|| anyhow::anyhow!("`output_channel` not set"))?,
             finish_handle: FinishHandle::new(),
             mock_snos_from_pie: self.mock_snos_from_pie,
             db: self.db,
@@ -329,24 +329,24 @@ where
         })
     }
 
-    fn statement_channel(mut self, statement_channel: Receiver<BlockInfo>) -> Self {
-        self.statement_channel = Some(statement_channel);
+    fn input_channel(mut self, input_channel: Receiver<BlockInfo>) -> Self {
+        self.input_channel = Some(input_channel);
         self
     }
 
-    fn proof_channel(mut self, proof_channel: Sender<SnosProof<P>>) -> Self {
-        self.proof_channel = Some(proof_channel);
+    fn output_channel(mut self, output_channel: Sender<SnosProof<P>>) -> Self {
+        self.output_channel = Some(output_channel);
         self
     }
 }
 
-impl<P, DB> Prover for AtlanticSnosProver<P, DB>
+impl<P, DB> PipelineStage for AtlanticSnosProver<P, DB>
 where
     P: AtlanticProof + Send + Sync + 'static,
     DB: PersistantStorage + Send + Sync + Clone + 'static,
 {
-    type Statement = BlockInfo;
-    type BlockInfo = SnosProof<P>;
+    type Input = BlockInfo;
+    type Output = SnosProof<P>;
 }
 
 impl<P, DB> Daemon for AtlanticSnosProver<P, DB>

--- a/saya/core/src/prover/block_orderer.rs
+++ b/saya/core/src/prover/block_orderer.rs
@@ -1,0 +1,132 @@
+use std::{collections::BTreeMap, marker::PhantomData};
+
+use anyhow::Result;
+use log::debug;
+use tokio::sync::mpsc::{Receiver, Sender};
+
+use crate::{
+    prover::{HasBlockNumber, PipelineStage, PipelineStageBuilder},
+    service::{Daemon, FinishHandle, ShutdownHandle},
+};
+
+/// A pipeline stage that reorders items from concurrent upstream workers into sequential order.
+///
+/// Workers may complete blocks out of order. `BlockOrderer` buffers items in a `BTreeMap` and
+/// emits them strictly in ascending block-number order, starting from `start_block`.
+#[derive(Debug)]
+pub struct BlockOrderer<T> {
+    input_channel: Receiver<T>,
+    output_channel: Sender<T>,
+    finish_handle: FinishHandle,
+    start_block: u64,
+}
+
+#[derive(Debug)]
+pub struct BlockOrdererBuilder<T> {
+    input_channel: Option<Receiver<T>>,
+    output_channel: Option<Sender<T>>,
+    start_block: Option<u64>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> BlockOrdererBuilder<T> {
+    pub fn new() -> Self {
+        Self {
+            input_channel: None,
+            output_channel: None,
+            start_block: None,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> Default for BlockOrdererBuilder<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> PipelineStageBuilder for BlockOrdererBuilder<T>
+where
+    T: HasBlockNumber + Send + 'static,
+{
+    type Stage = BlockOrderer<T>;
+
+    fn build(self) -> Result<Self::Stage> {
+        Ok(BlockOrderer {
+            input_channel: self
+                .input_channel
+                .ok_or_else(|| anyhow::anyhow!("`input_channel` not set"))?,
+            output_channel: self
+                .output_channel
+                .ok_or_else(|| anyhow::anyhow!("`output_channel` not set"))?,
+            finish_handle: FinishHandle::new(),
+            start_block: self
+                .start_block
+                .ok_or_else(|| anyhow::anyhow!("`start_block` not set on BlockOrderer"))?,
+        })
+    }
+
+    fn input_channel(mut self, input_channel: Receiver<T>) -> Self {
+        self.input_channel = Some(input_channel);
+        self
+    }
+
+    fn output_channel(mut self, output_channel: Sender<T>) -> Self {
+        self.output_channel = Some(output_channel);
+        self
+    }
+
+    fn start_block(mut self, start_block: u64) -> Self {
+        self.start_block = Some(start_block);
+        self
+    }
+}
+
+impl<T: HasBlockNumber + Send + 'static> PipelineStage for BlockOrderer<T> {
+    type Input = T;
+    type Output = T;
+}
+
+impl<T: HasBlockNumber + Send + 'static> Daemon for BlockOrderer<T> {
+    fn shutdown_handle(&self) -> ShutdownHandle {
+        self.finish_handle.shutdown_handle()
+    }
+
+    fn start(self) {
+        tokio::spawn(self.run());
+    }
+}
+
+impl<T: HasBlockNumber + Send + 'static> BlockOrderer<T> {
+    async fn run(mut self) {
+        let mut pending: BTreeMap<u64, T> = BTreeMap::new();
+        let mut next_expected = self.start_block;
+
+        loop {
+            // Drain buffered items in order before waiting for more.
+            while let Some(item) = pending.remove(&next_expected) {
+                if self.output_channel.send(item).await.is_err() {
+                    debug!("BlockOrderer output channel closed");
+                    self.finish_handle.finish();
+                    return;
+                }
+                next_expected += 1;
+            }
+
+            // Wait for the next upstream item.
+            let item = tokio::select! {
+                _ = self.finish_handle.shutdown_requested() => break,
+                item = self.input_channel.recv() => match item {
+                    Some(item) => item,
+                    None => break,
+                },
+            };
+
+            pending.insert(item.block_number(), item);
+        }
+
+        debug!("BlockOrderer graceful shutdown finished");
+        self.finish_handle.finish();
+    }
+}

--- a/saya/core/src/prover/mock/layout_bridge.rs
+++ b/saya/core/src/prover/mock/layout_bridge.rs
@@ -8,16 +8,16 @@ use tokio::sync::mpsc::{Receiver, Sender};
 
 use crate::storage::PersistantStorage;
 use crate::{
-    prover::{Prover, ProverBuilder, RecursiveProof, SnosProof},
+    prover::{PipelineStage, PipelineStageBuilder, RecursiveProof, SnosProof},
     service::{Daemon, FinishHandle, ShutdownHandle},
     utils::calculate_output,
 };
-/// Prover implementation as a client to the hosted [Mock Prover](https://atlanticprover.com/)
+/// Prover implementation as a client to the hosted [Mock Prover](https://docs.herodotus.cloud/atlantic-api/introduction)
 /// service.
 #[derive(Debug)]
 pub struct MockLayoutBridgeProver<DB> {
-    statement_channel: Receiver<SnosProof<String>>,
-    block_info_channel: Sender<BlockInfo>,
+    input_channel: Receiver<SnosProof<String>>,
+    output_channel: Sender<BlockInfo>,
     layout_bridge_program_hash: Felt,
     finish_handle: FinishHandle,
     db: DB,
@@ -25,8 +25,8 @@ pub struct MockLayoutBridgeProver<DB> {
 
 #[derive(Debug, Default)]
 pub struct MockLayoutBridgeProverBuilder<DB> {
-    statement_channel: Option<Receiver<SnosProof<String>>>,
-    block_info_channel: Option<Sender<BlockInfo>>,
+    input_channel: Option<Receiver<SnosProof<String>>>,
+    output_channel: Option<Sender<BlockInfo>>,
     layout_bridge_program_hash: Felt,
     db: DB,
 }
@@ -39,7 +39,7 @@ where
         loop {
             let new_snos_proof = tokio::select! {
                 _ = self.finish_handle.shutdown_requested() => break,
-                new_snos_proof = self.statement_channel.recv() => new_snos_proof,
+                new_snos_proof = self.input_channel.recv() => new_snos_proof,
             };
             // This should be fine for now as block ingestors wouldn't drop senders. This might
             // change in the future.
@@ -112,7 +112,7 @@ where
             };
             tokio::select! {
                 _ = self.finish_handle.shutdown_requested() => break,
-                _ = self.block_info_channel.send(new_proof) => {},
+                _ = self.output_channel.send(new_proof) => {},
             }
         }
 
@@ -124,51 +124,51 @@ where
 impl<DB> MockLayoutBridgeProverBuilder<DB> {
     pub fn new(layout_bridge_program_hash: Felt, db: DB) -> Self {
         Self {
-            statement_channel: None,
-            block_info_channel: None,
+            input_channel: None,
+            output_channel: None,
             layout_bridge_program_hash,
             db,
         }
     }
 }
 
-impl<DB> ProverBuilder for MockLayoutBridgeProverBuilder<DB>
+impl<DB> PipelineStageBuilder for MockLayoutBridgeProverBuilder<DB>
 where
     DB: PersistantStorage + Send + Sync + Clone + 'static,
 {
-    type Prover = MockLayoutBridgeProver<DB>;
+    type Stage = MockLayoutBridgeProver<DB>;
 
-    fn build(self) -> Result<Self::Prover> {
+    fn build(self) -> Result<Self::Stage> {
         Ok(MockLayoutBridgeProver {
-            statement_channel: self
-                .statement_channel
-                .ok_or_else(|| anyhow::anyhow!("`statement_channel` not set"))?,
-            block_info_channel: self
-                .block_info_channel
-                .ok_or_else(|| anyhow::anyhow!("`proof_channel` not set"))?,
+            input_channel: self
+                .input_channel
+                .ok_or_else(|| anyhow::anyhow!("`input_channel` not set"))?,
+            output_channel: self
+                .output_channel
+                .ok_or_else(|| anyhow::anyhow!("`output_channel` not set"))?,
             finish_handle: FinishHandle::new(),
             layout_bridge_program_hash: self.layout_bridge_program_hash,
             db: self.db,
         })
     }
 
-    fn statement_channel(mut self, statement_channel: Receiver<SnosProof<String>>) -> Self {
-        self.statement_channel = Some(statement_channel);
+    fn input_channel(mut self, input_channel: Receiver<SnosProof<String>>) -> Self {
+        self.input_channel = Some(input_channel);
         self
     }
 
-    fn proof_channel(mut self, proof_channel: Sender<BlockInfo>) -> Self {
-        self.block_info_channel = Some(proof_channel);
+    fn output_channel(mut self, output_channel: Sender<BlockInfo>) -> Self {
+        self.output_channel = Some(output_channel);
         self
     }
 }
 
-impl<DB> Prover for MockLayoutBridgeProver<DB>
+impl<DB> PipelineStage for MockLayoutBridgeProver<DB>
 where
     DB: PersistantStorage + Send + Sync + Clone + 'static,
 {
-    type Statement = SnosProof<String>;
-    type BlockInfo = BlockInfo;
+    type Input = SnosProof<String>;
+    type Output = BlockInfo;
 }
 
 impl<DB> Daemon for MockLayoutBridgeProver<DB>

--- a/saya/core/src/prover/mock/layout_bridge.rs
+++ b/saya/core/src/prover/mock/layout_bridge.rs
@@ -95,7 +95,7 @@ where
                 )
                 .await
                 .unwrap();
-            let new_proof = RecursiveProof {
+            let recursive_proof = RecursiveProof {
                 block_number: new_snos_proof.block_number,
                 snos_output,
                 layout_bridge_proof: mock_proof,
@@ -105,14 +105,14 @@ where
                 "Mock proof generated for block #{}",
                 new_snos_proof.block_number
             );
-            let new_proof = BlockInfo {
-                number: new_proof.block_number,
+            let output = BlockInfo {
+                number: recursive_proof.block_number,
                 status: crate::storage::BlockStatus::BridgeProofGenerated,
                 state_update: Some(state_update),
             };
             tokio::select! {
                 _ = self.finish_handle.shutdown_requested() => break,
-                _ = self.output_channel.send(new_proof) => {},
+                _ = self.output_channel.send(output) => {},
             }
         }
 

--- a/saya/core/src/prover/mod.rs
+++ b/saya/core/src/prover/mod.rs
@@ -56,12 +56,10 @@ pub trait PipelineStageBuilder {
 
     fn build(self) -> Result<Self::Stage>;
 
-    fn input_channel(
-        self,
-        block_channel: Receiver<<Self::Stage as PipelineStage>::Input>,
-    ) -> Self;
+    fn input_channel(self, block_channel: Receiver<<Self::Stage as PipelineStage>::Input>) -> Self;
 
-    fn output_channel(self, output_channel: Sender<<Self::Stage as PipelineStage>::Output>) -> Self;
+    fn output_channel(self, output_channel: Sender<<Self::Stage as PipelineStage>::Output>)
+        -> Self;
 
     /// Propagate the starting block number to interested stages (e.g. `BlockOrderer`).
     ///

--- a/saya/core/src/prover/mod.rs
+++ b/saya/core/src/prover/mod.rs
@@ -21,6 +21,9 @@ pub use atlantic::{
 mod mock;
 pub use mock::{MockLayoutBridgeProver, MockLayoutBridgeProverBuilder};
 mod recursive;
+
+mod snos_pie_generator;
+pub use snos_pie_generator::{SnosPieGenerator, SnosPieGeneratorBuilder};
 pub use atlantic::compress_pie;
 pub use atlantic::AtlanticClient;
 pub use recursive::{RecursiveProver, RecursiveProverBuilder};

--- a/saya/core/src/prover/mod.rs
+++ b/saya/core/src/prover/mod.rs
@@ -24,28 +24,59 @@ mod recursive;
 
 mod snos_pie_generator;
 pub use snos_pie_generator::{SnosPieGenerator, SnosPieGeneratorBuilder};
+
+mod block_orderer;
+pub use block_orderer::{BlockOrderer, BlockOrdererBuilder};
+
 pub use atlantic::compress_pie;
 pub use atlantic::AtlanticClient;
-pub use recursive::{RecursiveProver, RecursiveProverBuilder};
+pub use recursive::{PipelineChain, PipelineChainBuilder};
 
 pub mod error;
 
-pub trait ProverBuilder {
-    type Prover: Prover;
-
-    fn build(self) -> Result<Self::Prover>;
-
-    fn statement_channel(
-        self,
-        block_channel: Receiver<<Self::Prover as Prover>::Statement>,
-    ) -> Self;
-
-    fn proof_channel(self, proof_channel: Sender<<Self::Prover as Prover>::BlockInfo>) -> Self;
+/// Implemented by pipeline items that carry a block number.
+pub trait HasBlockNumber {
+    fn block_number(&self) -> u64;
 }
 
-pub trait Prover: Daemon {
-    type Statement;
-    type BlockInfo;
+impl HasBlockNumber for BlockInfo {
+    fn block_number(&self) -> u64 {
+        self.number
+    }
+}
+
+impl<P> HasBlockNumber for SnosProof<P> {
+    fn block_number(&self) -> u64 {
+        self.block_number
+    }
+}
+
+pub trait PipelineStageBuilder {
+    type Stage: PipelineStage;
+
+    fn build(self) -> Result<Self::Stage>;
+
+    fn input_channel(
+        self,
+        block_channel: Receiver<<Self::Stage as PipelineStage>::Input>,
+    ) -> Self;
+
+    fn output_channel(self, output_channel: Sender<<Self::Stage as PipelineStage>::Output>) -> Self;
+
+    /// Propagate the starting block number to interested stages (e.g. `BlockOrderer`).
+    ///
+    /// The default implementation is a no-op; stages that need `start_block` should override it.
+    fn start_block(self, _start_block: u64) -> Self
+    where
+        Self: Sized,
+    {
+        self
+    }
+}
+
+pub trait PipelineStage: Daemon {
+    type Input;
+    type Output;
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/saya/core/src/prover/recursive.rs
+++ b/saya/core/src/prover/recursive.rs
@@ -50,31 +50,23 @@ where
         let (bridge_tx, bridge_rx) = tokio::sync::mpsc::channel::<I>(BRIDGE_BUFFER_SIZE);
 
         Ok(PipelineChain {
-            upstream: self
-                .upstream_builder
-                .output_channel(bridge_tx)
-                .build()?,
-            downstream: self
-                .downstream_builder
-                .input_channel(bridge_rx)
-                .build()?,
+            upstream: self.upstream_builder.output_channel(bridge_tx).build()?,
+            downstream: self.downstream_builder.input_channel(bridge_rx).build()?,
             finish_handle: FinishHandle::new(),
         })
     }
 
-    fn input_channel(
-        self,
-        block_channel: Receiver<<Self::Stage as PipelineStage>::Input>,
-    ) -> Self {
+    fn input_channel(self, block_channel: Receiver<<Self::Stage as PipelineStage>::Input>) -> Self {
         Self {
-            upstream_builder: self
-                .upstream_builder
-                .input_channel(block_channel),
+            upstream_builder: self.upstream_builder.input_channel(block_channel),
             downstream_builder: self.downstream_builder,
         }
     }
 
-    fn output_channel(self, output_channel: Sender<<Self::Stage as PipelineStage>::Output>) -> Self {
+    fn output_channel(
+        self,
+        output_channel: Sender<<Self::Stage as PipelineStage>::Output>,
+    ) -> Self {
         Self {
             upstream_builder: self.upstream_builder,
             downstream_builder: self.downstream_builder.output_channel(output_channel),

--- a/saya/core/src/prover/recursive.rs
+++ b/saya/core/src/prover/recursive.rs
@@ -3,97 +3,104 @@ use log::debug;
 use tokio::sync::mpsc::{Receiver, Sender};
 
 use crate::{
-    prover::{Prover, ProverBuilder},
+    prover::{PipelineStage, PipelineStageBuilder},
     service::{Daemon, FinishHandle, ShutdownHandle},
 };
 
 const BRIDGE_BUFFER_SIZE: usize = 4;
 
 #[derive(Debug)]
-pub struct RecursiveProver<U, D> {
-    upstream_prover: U,
-    downstream_prover: D,
+pub struct PipelineChain<U, D> {
+    upstream: U,
+    downstream: D,
     finish_handle: FinishHandle,
 }
 
 #[derive(Debug)]
-pub struct RecursiveProverBuilder<U, D> {
-    upstream_prover_builder: U,
-    downstream_prover_builder: D,
+pub struct PipelineChainBuilder<U, D> {
+    upstream_builder: U,
+    downstream_builder: D,
 }
 
-struct RecursiveProverState {
-    upstream_prover_handle: ShutdownHandle,
-    downstream_prover_handle: ShutdownHandle,
+struct PipelineChainState {
+    upstream_handle: ShutdownHandle,
+    downstream_handle: ShutdownHandle,
     finish_handle: FinishHandle,
 }
 
-impl<U, D> RecursiveProverBuilder<U, D> {
-    pub fn new(upstream_prover_builder: U, downstream_prover_builder: D) -> Self {
+impl<U, D> PipelineChainBuilder<U, D> {
+    pub fn new(upstream_builder: U, downstream_builder: D) -> Self {
         Self {
-            upstream_prover_builder,
-            downstream_prover_builder,
+            upstream_builder,
+            downstream_builder,
         }
     }
 }
 
-impl<U, D, UV, DV, I> ProverBuilder for RecursiveProverBuilder<U, D>
+impl<U, D, UV, DV, I> PipelineStageBuilder for PipelineChainBuilder<U, D>
 where
-    U: ProverBuilder<Prover = UV>,
-    D: ProverBuilder<Prover = DV>,
-    UV: Prover<BlockInfo = I>,
-    DV: Prover<Statement = I>,
+    U: PipelineStageBuilder<Stage = UV>,
+    D: PipelineStageBuilder<Stage = DV>,
+    UV: PipelineStage<Output = I>,
+    DV: PipelineStage<Input = I>,
 {
-    type Prover = RecursiveProver<U::Prover, D::Prover>;
+    type Stage = PipelineChain<U::Stage, D::Stage>;
 
-    fn build(self) -> Result<Self::Prover> {
+    fn build(self) -> Result<Self::Stage> {
         let (bridge_tx, bridge_rx) = tokio::sync::mpsc::channel::<I>(BRIDGE_BUFFER_SIZE);
 
-        Ok(RecursiveProver {
-            upstream_prover: self
-                .upstream_prover_builder
-                .proof_channel(bridge_tx)
+        Ok(PipelineChain {
+            upstream: self
+                .upstream_builder
+                .output_channel(bridge_tx)
                 .build()?,
-            downstream_prover: self
-                .downstream_prover_builder
-                .statement_channel(bridge_rx)
+            downstream: self
+                .downstream_builder
+                .input_channel(bridge_rx)
                 .build()?,
             finish_handle: FinishHandle::new(),
         })
     }
 
-    fn statement_channel(
+    fn input_channel(
         self,
-        block_channel: Receiver<<Self::Prover as Prover>::Statement>,
+        block_channel: Receiver<<Self::Stage as PipelineStage>::Input>,
     ) -> Self {
         Self {
-            upstream_prover_builder: self
-                .upstream_prover_builder
-                .statement_channel(block_channel),
-            downstream_prover_builder: self.downstream_prover_builder,
+            upstream_builder: self
+                .upstream_builder
+                .input_channel(block_channel),
+            downstream_builder: self.downstream_builder,
         }
     }
 
-    fn proof_channel(self, proof_channel: Sender<<Self::Prover as Prover>::BlockInfo>) -> Self {
+    fn output_channel(self, output_channel: Sender<<Self::Stage as PipelineStage>::Output>) -> Self {
         Self {
-            upstream_prover_builder: self.upstream_prover_builder,
-            downstream_prover_builder: self.downstream_prover_builder.proof_channel(proof_channel),
+            upstream_builder: self.upstream_builder,
+            downstream_builder: self.downstream_builder.output_channel(output_channel),
+        }
+    }
+
+    fn start_block(self, start_block: u64) -> Self {
+        Self {
+            upstream_builder: self.upstream_builder.start_block(start_block),
+            downstream_builder: self.downstream_builder.start_block(start_block),
         }
     }
 }
 
-impl RecursiveProverState {
+impl PipelineChainState {
     async fn run(self) {
         self.finish_handle.shutdown_requested().await;
 
         // Request graceful shutdown for all descendant services
-        self.upstream_prover_handle.shutdown();
-        self.downstream_prover_handle.shutdown();
+        self.upstream_handle.shutdown();
+        self.downstream_handle.shutdown();
 
         // Wait for all descendant services to finish graceful shutdown
         futures_util::future::join_all([
-            self.upstream_prover_handle.finished(),
-            self.downstream_prover_handle.finished(),
+            self.upstream_handle.finished(),
+            self.downstream_handle.finished(),
         ])
         .await;
 
@@ -102,33 +109,33 @@ impl RecursiveProverState {
     }
 }
 
-impl<U, D, I> Prover for RecursiveProver<U, D>
+impl<U, D, I> PipelineStage for PipelineChain<U, D>
 where
-    U: Prover<BlockInfo = I>,
-    D: Prover<Statement = I>,
+    U: PipelineStage<Output = I>,
+    D: PipelineStage<Input = I>,
 {
-    type Statement = U::Statement;
-    type BlockInfo = D::BlockInfo;
+    type Input = U::Input;
+    type Output = D::Output;
 }
 
-impl<U, D, I> Daemon for RecursiveProver<U, D>
+impl<U, D, I> Daemon for PipelineChain<U, D>
 where
-    U: Prover<BlockInfo = I>,
-    D: Prover<Statement = I>,
+    U: PipelineStage<Output = I>,
+    D: PipelineStage<Input = I>,
 {
     fn shutdown_handle(&self) -> ShutdownHandle {
         self.finish_handle.shutdown_handle()
     }
 
     fn start(self) {
-        let state = RecursiveProverState {
-            upstream_prover_handle: self.upstream_prover.shutdown_handle(),
-            downstream_prover_handle: self.downstream_prover.shutdown_handle(),
+        let state = PipelineChainState {
+            upstream_handle: self.upstream.shutdown_handle(),
+            downstream_handle: self.downstream.shutdown_handle(),
             finish_handle: self.finish_handle,
         };
 
-        self.upstream_prover.start();
-        self.downstream_prover.start();
+        self.upstream.start();
+        self.downstream.start();
 
         tokio::spawn(state.run());
     }

--- a/saya/core/src/prover/snos_pie_generator.rs
+++ b/saya/core/src/prover/snos_pie_generator.rs
@@ -1,0 +1,245 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use cairo_vm::vm::runners::cairo_pie::CairoPie;
+use generate_pie::{
+    generate_pie,
+    types::{ChainConfig, OsHintsConfiguration},
+};
+use log::{debug, error, info, trace};
+use starknet_api::{contract_address, core::ChainId};
+use tokio::{
+    sync::{
+        mpsc::{Receiver, Sender},
+        Mutex,
+    },
+    task,
+};
+use url::Url;
+
+use crate::{
+    block_ingestor::BlockInfo,
+    prover::{compress_pie, Prover, ProverBuilder},
+    service::{Daemon, FinishHandle, ShutdownHandle},
+    storage::{BlockStatus, PersistantStorage, Step},
+};
+
+const KATANA_DEFAULT_TOKEN_ADDRESS: &str =
+    "0x2e7442625bab778683501c0eadbc1ea17b3535da040a12ac7d281066e915eea";
+
+/// A pipeline component that generates a Cairo PIE from a `BlockInfo { status: Mined }` and
+/// emits `BlockInfo { status: SnosPieGenerated }` for the SNOS prover downstream.
+///
+/// This is the stage that was previously embedded inside `PollingBlockIngestor`. Extracting it
+/// allows the block ingestor to remain proving-strategy-agnostic and makes it straightforward
+/// to swap in a different preparation step (e.g. TEE attestation) without touching block control.
+#[derive(Debug)]
+pub struct SnosPieGenerator<DB> {
+    rpc_url: Url,
+    statement_channel: Receiver<BlockInfo>,
+    proof_channel: Sender<BlockInfo>,
+    finish_handle: FinishHandle,
+    db: DB,
+    workers_count: usize,
+    os_hints_config: OsHintsConfiguration,
+    chain_id: ChainId,
+}
+
+#[derive(Debug)]
+pub struct SnosPieGeneratorBuilder<DB> {
+    rpc_url: Url,
+    statement_channel: Option<Receiver<BlockInfo>>,
+    proof_channel: Option<Sender<BlockInfo>>,
+    db: DB,
+    workers_count: usize,
+    os_hints_config: OsHintsConfiguration,
+    chain_id: ChainId,
+}
+
+impl<DB> SnosPieGenerator<DB>
+where
+    DB: PersistantStorage + Send + Sync + Clone + 'static,
+{
+    async fn worker(
+        task_rx: Arc<Mutex<Receiver<BlockInfo>>>,
+        task_tx: Sender<BlockInfo>,
+        rpc_url: Url,
+        finish_handle: FinishHandle,
+        db: DB,
+        os_hints_config: OsHintsConfiguration,
+        chain_id: ChainId,
+    ) {
+        loop {
+            let block_info = if let Some(b) = task_rx.lock().await.recv().await {
+                b
+            } else {
+                break;
+            };
+
+            let block_number = block_info.number;
+            let block_number_u32: u32 = block_number.try_into().unwrap();
+
+            if finish_handle.is_shutdown_requested() {
+                break;
+            }
+
+            // Resume: reuse an existing PIE from the DB if available.
+            match db.get_pie(block_number_u32, Step::Snos).await {
+                Ok(pie_bytes) => match CairoPie::from_bytes(&pie_bytes) {
+                    Ok(_) => {
+                        trace!(block_number; "SNOS PIE already in DB, skipping generation");
+                        let out = BlockInfo {
+                            number: block_number,
+                            status: BlockStatus::SnosPieGenerated,
+                            state_update: block_info.state_update,
+                        };
+                        if task_tx.send(out).await.is_err() {
+                            error!(block_number; "Failed to forward block after PIE resume");
+                        }
+                        continue;
+                    }
+                    Err(err) => {
+                        error!(block_number, error:% = err; "Failed to parse existing PIE from DB");
+                    }
+                },
+                Err(err) => {
+                    trace!(block_number, error:% = err; "SNOS PIE not found in DB, generating");
+                }
+            }
+
+            let pie_input = generate_pie::types::PieGenerationInput {
+                rpc_url: rpc_url.to_string(),
+                blocks: vec![block_number],
+                versioned_constants: None,
+                chain_config: ChainConfig {
+                    chain_id: chain_id.clone(),
+                    strk_fee_token_address: contract_address!(KATANA_DEFAULT_TOKEN_ADDRESS),
+                    is_l3: true,
+                    eth_fee_token_address: contract_address!(KATANA_DEFAULT_TOKEN_ADDRESS),
+                },
+                layout: cairo_vm::types::layout_name::LayoutName::all_cairo,
+                os_hints_config: os_hints_config.clone(),
+                output_path: None,
+            };
+
+            let pie = generate_pie(pie_input).await.unwrap().output.cairo_pie;
+
+            if finish_handle.is_shutdown_requested() {
+                break;
+            }
+
+            let pie_bytes = compress_pie(pie).await.unwrap();
+            db.add_pie(block_number_u32, pie_bytes, Step::Snos)
+                .await
+                .unwrap();
+
+            info!(block_number; "SNOS PIE generated for block");
+
+            let out = BlockInfo {
+                number: block_number,
+                status: BlockStatus::SnosPieGenerated,
+                state_update: block_info.state_update,
+            };
+
+            if task_tx.send(out).await.is_err() {
+                error!(block_number; "Failed to forward block after PIE generation");
+            }
+        }
+    }
+
+    async fn run(self) {
+        let mut workers = Vec::new();
+        let task_rx = Arc::new(Mutex::new(self.statement_channel));
+
+        for _ in 0..self.workers_count {
+            workers.push(task::spawn(Self::worker(
+                task_rx.clone(),
+                self.proof_channel.clone(),
+                self.rpc_url.clone(),
+                self.finish_handle.clone(),
+                self.db.clone(),
+                self.os_hints_config.clone(),
+                self.chain_id.clone(),
+            )));
+        }
+
+        futures_util::future::join_all(workers).await;
+        debug!("Graceful shutdown finished");
+        self.finish_handle.finish();
+    }
+}
+
+impl<DB> SnosPieGeneratorBuilder<DB> {
+    pub fn new(
+        rpc_url: Url,
+        db: DB,
+        workers_count: usize,
+        os_hints_config: OsHintsConfiguration,
+        chain_id: ChainId,
+    ) -> Self {
+        Self {
+            rpc_url,
+            statement_channel: None,
+            proof_channel: None,
+            db,
+            workers_count,
+            os_hints_config,
+            chain_id,
+        }
+    }
+}
+
+impl<DB> ProverBuilder for SnosPieGeneratorBuilder<DB>
+where
+    DB: PersistantStorage + Send + Sync + Clone + 'static,
+{
+    type Prover = SnosPieGenerator<DB>;
+
+    fn build(self) -> Result<Self::Prover> {
+        Ok(SnosPieGenerator {
+            rpc_url: self.rpc_url,
+            statement_channel: self
+                .statement_channel
+                .ok_or_else(|| anyhow::anyhow!("`statement_channel` not set"))?,
+            proof_channel: self
+                .proof_channel
+                .ok_or_else(|| anyhow::anyhow!("`proof_channel` not set"))?,
+            finish_handle: FinishHandle::new(),
+            db: self.db,
+            workers_count: self.workers_count,
+            os_hints_config: self.os_hints_config,
+            chain_id: self.chain_id,
+        })
+    }
+
+    fn statement_channel(mut self, statement_channel: Receiver<BlockInfo>) -> Self {
+        self.statement_channel = Some(statement_channel);
+        self
+    }
+
+    fn proof_channel(mut self, proof_channel: Sender<BlockInfo>) -> Self {
+        self.proof_channel = Some(proof_channel);
+        self
+    }
+}
+
+impl<DB> Prover for SnosPieGenerator<DB>
+where
+    DB: PersistantStorage + Send + Sync + Clone + 'static,
+{
+    type Statement = BlockInfo;
+    type BlockInfo = BlockInfo;
+}
+
+impl<DB> Daemon for SnosPieGenerator<DB>
+where
+    DB: PersistantStorage + Send + Sync + Clone + 'static,
+{
+    fn shutdown_handle(&self) -> ShutdownHandle {
+        self.finish_handle.shutdown_handle()
+    }
+
+    fn start(self) {
+        tokio::spawn(self.run());
+    }
+}

--- a/saya/core/src/prover/snos_pie_generator.rs
+++ b/saya/core/src/prover/snos_pie_generator.rs
@@ -19,7 +19,7 @@ use url::Url;
 
 use crate::{
     block_ingestor::BlockInfo,
-    prover::{compress_pie, Prover, ProverBuilder},
+    prover::{compress_pie, PipelineStage, PipelineStageBuilder},
     service::{Daemon, FinishHandle, ShutdownHandle},
     storage::{BlockStatus, PersistantStorage, Step},
 };
@@ -36,8 +36,8 @@ const KATANA_DEFAULT_TOKEN_ADDRESS: &str =
 #[derive(Debug)]
 pub struct SnosPieGenerator<DB> {
     rpc_url: Url,
-    statement_channel: Receiver<BlockInfo>,
-    proof_channel: Sender<BlockInfo>,
+    input_channel: Receiver<BlockInfo>,
+    output_channel: Sender<BlockInfo>,
     finish_handle: FinishHandle,
     db: DB,
     workers_count: usize,
@@ -48,8 +48,8 @@ pub struct SnosPieGenerator<DB> {
 #[derive(Debug)]
 pub struct SnosPieGeneratorBuilder<DB> {
     rpc_url: Url,
-    statement_channel: Option<Receiver<BlockInfo>>,
-    proof_channel: Option<Sender<BlockInfo>>,
+    input_channel: Option<Receiver<BlockInfo>>,
+    output_channel: Option<Sender<BlockInfo>>,
     db: DB,
     workers_count: usize,
     os_hints_config: OsHintsConfiguration,
@@ -149,12 +149,12 @@ where
 
     async fn run(self) {
         let mut workers = Vec::new();
-        let task_rx = Arc::new(Mutex::new(self.statement_channel));
+        let task_rx = Arc::new(Mutex::new(self.input_channel));
 
         for _ in 0..self.workers_count {
             workers.push(task::spawn(Self::worker(
                 task_rx.clone(),
-                self.proof_channel.clone(),
+                self.output_channel.clone(),
                 self.rpc_url.clone(),
                 self.finish_handle.clone(),
                 self.db.clone(),
@@ -179,8 +179,8 @@ impl<DB> SnosPieGeneratorBuilder<DB> {
     ) -> Self {
         Self {
             rpc_url,
-            statement_channel: None,
-            proof_channel: None,
+            input_channel: None,
+            output_channel: None,
             db,
             workers_count,
             os_hints_config,
@@ -189,21 +189,21 @@ impl<DB> SnosPieGeneratorBuilder<DB> {
     }
 }
 
-impl<DB> ProverBuilder for SnosPieGeneratorBuilder<DB>
+impl<DB> PipelineStageBuilder for SnosPieGeneratorBuilder<DB>
 where
     DB: PersistantStorage + Send + Sync + Clone + 'static,
 {
-    type Prover = SnosPieGenerator<DB>;
+    type Stage = SnosPieGenerator<DB>;
 
-    fn build(self) -> Result<Self::Prover> {
+    fn build(self) -> Result<Self::Stage> {
         Ok(SnosPieGenerator {
             rpc_url: self.rpc_url,
-            statement_channel: self
-                .statement_channel
-                .ok_or_else(|| anyhow::anyhow!("`statement_channel` not set"))?,
-            proof_channel: self
-                .proof_channel
-                .ok_or_else(|| anyhow::anyhow!("`proof_channel` not set"))?,
+            input_channel: self
+                .input_channel
+                .ok_or_else(|| anyhow::anyhow!("`input_channel` not set"))?,
+            output_channel: self
+                .output_channel
+                .ok_or_else(|| anyhow::anyhow!("`output_channel` not set"))?,
             finish_handle: FinishHandle::new(),
             db: self.db,
             workers_count: self.workers_count,
@@ -212,23 +212,23 @@ where
         })
     }
 
-    fn statement_channel(mut self, statement_channel: Receiver<BlockInfo>) -> Self {
-        self.statement_channel = Some(statement_channel);
+    fn input_channel(mut self, input_channel: Receiver<BlockInfo>) -> Self {
+        self.input_channel = Some(input_channel);
         self
     }
 
-    fn proof_channel(mut self, proof_channel: Sender<BlockInfo>) -> Self {
-        self.proof_channel = Some(proof_channel);
+    fn output_channel(mut self, output_channel: Sender<BlockInfo>) -> Self {
+        self.output_channel = Some(output_channel);
         self
     }
 }
 
-impl<DB> Prover for SnosPieGenerator<DB>
+impl<DB> PipelineStage for SnosPieGenerator<DB>
 where
     DB: PersistantStorage + Send + Sync + Clone + 'static,
 {
-    type Statement = BlockInfo;
-    type BlockInfo = BlockInfo;
+    type Input = BlockInfo;
+    type Output = BlockInfo;
 }
 
 impl<DB> Daemon for SnosPieGenerator<DB>

--- a/saya/core/src/settlement/piltover.rs
+++ b/saya/core/src/settlement/piltover.rs
@@ -22,7 +22,6 @@ use starknet::{
 };
 use starknet_types_core::felt::Felt;
 use std::{
-    collections::BTreeMap,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -94,33 +93,14 @@ where
     }
 
     async fn run(mut self) {
-        let mut pending_blocks: BTreeMap<u64, DataAvailabilityCursor<BlockInfo>> = BTreeMap::new();
         loop {
-            let last_settled_block = self.get_block_number().await.unwrap();
-
-            let next_to_settle = if last_settled_block == Felt::MAX {
-                0
-            } else {
-                <Felt as TryInto<u64>>::try_into(last_settled_block).unwrap() + 1
+            let new_da = tokio::select! {
+                _ = self.finish_handle.shutdown_requested() => break,
+                new_da = self.da_channel.recv() => new_da,
             };
-
-            let da = pending_blocks.remove(&next_to_settle);
-
-            let Some(new_da) = da else {
-                let new_da = tokio::select! {
-                    _ = self.finish_handle.shutdown_requested() => break,
-                    new_da = self.da_channel.recv() => new_da,
-                };
-                let new_da = match new_da {
-                    Some(new_da) => new_da,
-                    None => {
-                        debug!("Data availability channel closed, shutting down");
-                        break;
-                    }
-                };
-
-                pending_blocks.insert(new_da.block_number, new_da.clone());
-                continue;
+            let Some(new_da) = new_da else {
+                debug!("Data availability channel closed, shutting down");
+                break;
             };
 
             debug!("Received new DA cursor");
@@ -233,7 +213,7 @@ where
                             );
                             self.db
                                 .set_status(
-                                    next_to_settle.try_into().unwrap(),
+                                    new_da.block_number.try_into().unwrap(),
                                     "verified_proof".to_string(),
                                 )
                                 .await


### PR DESCRIPTION
## Summary

- Introduces `PersistentTeeOrchestrator`: wires only a block ingestor and settlement backend, with no external prover or DA layer, laying the groundwork for TEE-based proving.
- Extracts `SnosPieGenerator` as a dedicated `PipelineStage` — `PollingBlockIngestor` now only controls block flow and emits `BlockInfo { status: Mined }`, keeping it proving-strategy-agnostic.
- Renames `Prover`/`ProverBuilder` traits → `PipelineStage`/`PipelineStageBuilder` with cleaner associated types (`Input`/`Output`) and `RecursiveProver` → `PipelineChain`.
- Adds `BlockOrderer<T>` pipeline stage that buffers out-of-order items from concurrent workers and emits them strictly in block-number order.

## Resolves

Closes #39 — Sovereign rollup mode block order.

The root cause was that concurrent prover workers could complete out of order, and the reorder buffer lived inside `PiltoverSettlementBackend` which only covered the persistent (Piltover) path. Sovereign mode had no ordering guarantee at all.

`BlockOrderer` is now wired at the end of the prover chain in both persistent and sovereign modes, guaranteeing sequential delivery to any downstream settlement or DA backend. The inline `BTreeMap` reorder buffer has been removed from `PiltoverSettlementBackend`.

## Test plan

- [ ] `cargo test --workspace --all-features` passes
- [ ] Sovereign mode end-to-end: verify blocks are settled in order under concurrent workers
- [ ] Persistent mode regression: Piltover settlement still receives blocks in order