### PR TITLE
chore: fix release workflow for split workspace structure

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -28,6 +28,9 @@ jobs:
           VERSION=${VERSION#v}
           cargo install cargo-release --version 0.25.19 --locked
           cargo release version $VERSION --execute --no-confirm && cargo release replace --execute --no-confirm
+          for dir in bin/persistent bin/ops bin/persistent-tee; do
+            (cd $dir && cargo release version $VERSION --execute --no-confirm)
+          done
 
       - id: version_info
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,9 @@ jobs:
           toolchain: "nightly-2024-12-16"
 
       - name: Install target
-        run: rustup target add ${{ matrix.job.target }}
+        run: |
+          rustup target add --toolchain 1.87 ${{ matrix.job.target }}
+          rustup target add --toolchain 1.91 ${{ matrix.job.target }}
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/bin/ops/Cargo.toml
+++ b/bin/ops/Cargo.toml
@@ -2,7 +2,7 @@
 resolver = "2"
 
 [workspace.package]
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"

--- a/bin/persistent-tee/Cargo.toml
+++ b/bin/persistent-tee/Cargo.toml
@@ -2,7 +2,7 @@
 resolver = "2"
 
 [workspace.package]
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"

--- a/bin/persistent/Cargo.toml
+++ b/bin/persistent/Cargo.toml
@@ -2,7 +2,7 @@
 resolver = "2"
 
 [workspace.package]
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Fix `E0463: can't find crate for 'core'` on `x86_64-apple-darwin`: install cross-compile targets against the actual sub-workspace toolchains (`1.87`, `1.91`) instead of the nightly toolchain that is no longer used for building
- Bump sub-workspace versions (`bin/persistent`, `bin/ops`, `bin/persistent-tee`) from `0.2.2` → `0.3.0` to match root after the workspace split left them stale
- `release-dispatch.yml` now bumps versions in all sub-workspaces during release prepare, so they stay in sync going forward

## Test plan
- [ ] Trigger release workflow and verify `x86_64-apple-darwin` build passes
- [ ] Trigger `release-dispatch` with a version bump and confirm all sub-workspace `Cargo.toml` files are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)