### PR TITLE
fix: remove readme field from sub-workspace Cargo.toml files

### DIFF
--- a/bin/ops/Cargo.toml
+++ b/bin/ops/Cargo.toml
@@ -5,7 +5,6 @@ resolver = "2"
 version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
-readme = "README.md"
 repository = "https://github.com/dojoengine/saya"
 
 [workspace.dependencies]
@@ -15,7 +14,6 @@ name = "ops"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-readme.workspace = true
 repository.workspace = true
 
 [dependencies]

--- a/bin/persistent-tee/Cargo.toml
+++ b/bin/persistent-tee/Cargo.toml
@@ -5,7 +5,6 @@ resolver = "2"
 version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
-readme = "README.md"
 repository = "https://github.com/dojoengine/saya"
 
 [workspace.dependencies]
@@ -15,7 +14,6 @@ name = "persistent-tee"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-readme.workspace = true
 repository.workspace = true
 
 [dependencies]

--- a/bin/persistent/Cargo.toml
+++ b/bin/persistent/Cargo.toml
@@ -5,7 +5,6 @@ resolver = "2"
 version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
-readme = "README.md"
 repository = "https://github.com/dojoengine/saya"
 
 [workspace.dependencies]
@@ -15,7 +14,6 @@ name = "persistent"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-readme.workspace = true
 repository.workspace = true
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Remove `readme = "README.md"` from `[workspace.package]` and `readme.workspace = true` from `[package]` in all three sub-workspaces
- `cargo release` fails during release-dispatch when the readme field is declared but no `README.md` exists in the sub-workspace directory

## Test plan
- [ ] Trigger `release-dispatch` and confirm version bump step completes without the readme error

🤖 Generated with [Claude Code](https://claude.com/claude-code)