### PR TITLE
feat: add persistent-tee to release and fix dispatch workflow

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -23,13 +23,18 @@ jobs:
         with:
           toolchain: "nightly"
 
+      - name: Setup SSH agent for private deps
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.KATANA_TEE_DEPLOY_KEY }}
+
       - run: |
           VERSION=${{ inputs.version }}
           VERSION=${VERSION#v}
           cargo install cargo-release --version 0.25.19 --locked
           cargo release version $VERSION --execute --no-confirm && cargo release replace --execute --no-confirm
           for dir in bin/persistent bin/ops bin/persistent-tee; do
-            (cd $dir && cargo release version $VERSION --execute --no-confirm)
+            (cd $dir && cargo release version $VERSION --allow-dirty --execute --no-confirm)
           done
 
       - id: version_info

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -34,7 +34,7 @@ jobs:
           cargo install cargo-release --version 0.25.19 --locked
           cargo release version $VERSION --execute --no-confirm && cargo release replace --execute --no-confirm
           for dir in bin/persistent bin/ops bin/persistent-tee; do
-            (cd $dir && cargo release version $VERSION --allow-dirty --execute --no-confirm)
+            (cd $dir && cargo release version $VERSION --execute --no-confirm)
           done
 
       - id: version_info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,11 @@ jobs:
           # See: https://github.com/jemalloc/jemalloc/issues/467
           echo "JEMALLOC_SYS_WITH_LG_PAGE=16" >> $GITHUB_ENV
 
+      - name: Setup SSH agent for private deps
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.KATANA_TEE_DEPLOY_KEY }}
+
       - name: Build binaries
         run: |
           cargo --version


### PR DESCRIPTION
## Summary
- Build, archive, and upload `persistent-tee` on all 4 platforms alongside `persistent` and `ops`
- Copy `persistent-tee` into the Docker image (`docker run ghcr.io/dojoengine/saya:latest persistent-tee <args>`)
- Remove invalid `readme` field from sub-workspace `Cargo.toml` files (caused `cargo release` to fail)
- Add `webfactory/ssh-agent` with `KATANA_TEE_DEPLOY_KEY` to `release.yml` and `release-dispatch.yml` for private `katana-tee` dependency
- Fix `--allow-dirty` invalid flag in `release-dispatch.yml`

## Test plan
- [ ] Merge and trigger `release-dispatch` with `0.4.0` — confirm all sub-workspace versions bump correctly
- [ ] Confirm release build produces `persistent-tee` artifacts on all platforms
- [ ] Pull Docker image and confirm `persistent-tee` is at `/usr/local/bin/persistent-tee`

🤖 Generated with [Claude Code](https://claude.com/claude-code)