### PR TITLE
chore: rename binaries to saya, saya-ops, saya-tee

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,21 +121,21 @@ jobs:
           VERSION_NAME: ${{ needs.prepare.outputs.tag_name }}
         run: |
           if [ "$PLATFORM_NAME" == "linux" ]; then
-            tar -czvf "persistent_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./bin/persistent/target/${TARGET}/release persistent
-            tar -czvf "ops_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./bin/ops/target/${TARGET}/release ops
-            tar -czvf "persistent-tee_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./bin/persistent-tee/target/${TARGET}/release persistent-tee
-            echo "persistent_file=persistent_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
-            echo "ops_file=ops_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
-            echo "persistent_tee_file=persistent-tee_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
+            tar -czvf "saya_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./bin/persistent/target/${TARGET}/release saya
+            tar -czvf "saya-ops_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./bin/ops/target/${TARGET}/release saya-ops
+            tar -czvf "saya-tee_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./bin/persistent-tee/target/${TARGET}/release saya-tee
+            echo "saya_file=saya_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
+            echo "saya_ops_file=saya-ops_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
+            echo "saya_tee_file=saya-tee_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
           elif [ "$PLATFORM_NAME" == "darwin" ]; then
             # We need to use gtar here otherwise the archive is corrupt.
             # See: https://github.com/actions/virtual-environments/issues/2619
-            gtar -czvf "persistent_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./bin/persistent/target/${TARGET}/release persistent
-            gtar -czvf "ops_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./bin/ops/target/${TARGET}/release ops
-            gtar -czvf "persistent-tee_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./bin/persistent-tee/target/${TARGET}/release persistent-tee
-            echo "persistent_file=persistent_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
-            echo "ops_file=ops_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
-            echo "persistent_tee_file=persistent-tee_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
+            gtar -czvf "saya_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./bin/persistent/target/${TARGET}/release saya
+            gtar -czvf "saya-ops_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./bin/ops/target/${TARGET}/release saya-ops
+            gtar -czvf "saya-tee_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C ./bin/persistent-tee/target/${TARGET}/release saya-tee
+            echo "saya_file=saya_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
+            echo "saya_ops_file=saya-ops_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
+            echo "saya_tee_file=saya-tee_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> $GITHUB_OUTPUT
           fi
         shell: bash
 
@@ -144,9 +144,9 @@ jobs:
         if: ${{ env.PLATFORM_NAME == 'linux' }}
         run: |
           mkdir -p $PLATFORM_NAME/$ARCH
-          mv bin/persistent/target/$TARGET/release/persistent $PLATFORM_NAME/$ARCH
-          mv bin/ops/target/$TARGET/release/ops $PLATFORM_NAME/$ARCH
-          mv bin/persistent-tee/target/$TARGET/release/persistent-tee $PLATFORM_NAME/$ARCH
+          mv bin/persistent/target/$TARGET/release/saya $PLATFORM_NAME/$ARCH/
+          mv bin/ops/target/$TARGET/release/saya-ops $PLATFORM_NAME/$ARCH/
+          mv bin/persistent-tee/target/$TARGET/release/saya-tee $PLATFORM_NAME/$ARCH/
         shell: bash
 
       - name: Upload docker binaries
@@ -161,9 +161,9 @@ jobs:
         with:
           name: artifacts-${{ matrix.job.target }}
           path: |
-            ${{ steps.artifacts.outputs.persistent_file }}
-            ${{ steps.artifacts.outputs.ops_file }}
-            ${{ steps.artifacts.outputs.persistent_tee_file }}
+            ${{ steps.artifacts.outputs.saya_file }}
+            ${{ steps.artifacts.outputs.saya_ops_file }}
+            ${{ steps.artifacts.outputs.saya_tee_file }}
           retention-days: 1
 
   build-programs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 
 RUN --mount=type=cache,target=/src/bin/persistent/target \
     mkdir -p ./build && \
-    cp ./bin/persistent/target/release/persistent ./build/
+    cp ./bin/persistent/target/release/saya ./build/
 
 # Build bin/ops (contract deployment utilities)
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
@@ -36,7 +36,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo build --release --manifest-path bin/ops/Cargo.toml
 
 RUN --mount=type=cache,target=/src/bin/ops/target \
-    cp ./bin/ops/target/release/ops ./build/
+    cp ./bin/ops/target/release/saya-ops ./build/
 
 # Generate layout_bridge program from cairo-lang source
 ARG CAIRO_VERSION=0.14.0.1
@@ -57,8 +57,8 @@ FROM alpine
 LABEL org.opencontainers.image.source=https://github.com/dojoengine/saya
 
 COPY --from=build /sbin/tini /tini
-COPY --from=build /src/build/persistent /usr/bin/
-COPY --from=build /src/build/ops /usr/bin/
+COPY --from=build /src/build/saya /usr/bin/
+COPY --from=build /src/build/saya-ops /usr/bin/
 COPY --from=build /programs /programs
 
 ENV LAYOUT_BRIDGE_PROGRAM=/programs/layout_bridge.json

--- a/Dockerfile-bins
+++ b/Dockerfile-bins
@@ -6,9 +6,9 @@ ARG TARGETPLATFORM
 
 LABEL org.opencontainers.image.source=https://github.com/dojoengine/saya
 
-COPY --from=binaries --chmod=755 $TARGETPLATFORM/persistent /usr/local/bin/
-COPY --from=binaries --chmod=755 $TARGETPLATFORM/ops /usr/local/bin/
-COPY --from=binaries --chmod=755 $TARGETPLATFORM/persistent-tee /usr/local/bin/
+COPY --from=binaries --chmod=755 $TARGETPLATFORM/saya /usr/local/bin/
+COPY --from=binaries --chmod=755 $TARGETPLATFORM/saya-ops /usr/local/bin/
+COPY --from=binaries --chmod=755 $TARGETPLATFORM/saya-tee /usr/local/bin/
 COPY ./programs /programs
 
 ENV LAYOUT_BRIDGE_PROGRAM=/programs/layout_bridge.json

--- a/README.md
+++ b/README.md
@@ -1,204 +1,124 @@
 # Saya
 
-Saya is a settlement service for Katana.
-
-## Binaries
-
-Saya is split into three independent binaries, each in its own Cargo workspace under `bin/`:
-
-| Binary | Workspace | Purpose |
-|--------|-----------|---------|
-| `persistent` | `bin/persistent/` | Settlement daemon — STARK/Atlantic proof pipeline, Piltover on-chain settlement, and sovereign (Celestia DA) mode |
-| `ops` | `bin/ops/` | Ops utilities — Piltover contract deployment and management, Celestia helpers |
-| `persistent-tee` | `bin/persistent-tee/` | TEE settlement daemon — AMD SEV-SNP attestation → SP1 proof → Piltover on-chain settlement |
-
-`saya/core` is a shared infrastructure library (no STARK or TEE-specific deps) used by all binaries.
+Saya is the proving and settlement orchestrator for the Dojo/Katana stack. It reads finalized blocks from a Katana rollup node and settles them on-chain.
 
 ---
 
-## Katana provable mode
+## Installation
 
-Katana must be running in **provable mode** to be proven by Saya.
-All commands described below are available starting from **Dojo `1.3.0`**.
+```bash
+asdf plugin add saya https://github.com/dojoengine/asdf-saya.git
+asdf install saya latest
+```
 
-### Important limitation
+This installs three commands: `saya`, `saya-ops`, and `saya-tee`.
 
-Provable Katana currently supports only **Starknet v14.0.1**.
-Because of this, Katana's built-in logic for deploying the core contract **cannot be used**.
-Instead, deployment is handled by the **`ops` binary**.
-
-### Correct flow
-
-1. Use the `ops` binary to:
-   - declare (or use the predeclared) core contract,
-   - deploy the contract,
-   - set the program info and fact registry.
-
-2. From this process, obtain:
-   - the **core contract address**,
-   - the **block number** where it was deployed.
-
-3. Use these values when running `katana init`.
+Alternatively, grab pre-built binaries from the [releases page](https://github.com/dojoengine/saya/releases) or use the Docker image `ghcr.io/dojoengine/saya`.
 
 ---
 
-## Ops binary (`bin/ops`)
+## Overview
 
-### Required environment variables
+### How it works
+
+```
+Katana L3 node  ──blocks──▶  Saya  ──proof + state──▶  Piltover (L2)
+```
+
+Saya polls Katana for finalized blocks, proves them (via Atlantic or TEE), and submits state updates to the Piltover settlement contract on L2.
+
+### Modes
+
+| Mode | Binary | How it proves | Settlement |
+|------|--------|---------------|------------|
+| Persistent | `persistent` | STARK proof via Atlantic (Herodotus) | Piltover on L2 |
+| Sovereign | `persistent` | STARK proof via Atlantic | Celestia DA (no on-chain settlement) |
+| Persistent-TEE | `persistent-tee` | AMD SEV-SNP attestation → SP1 Groth16 | Piltover on L2 |
+
+### What you need per mode
+
+| Requirement | Persistent | Sovereign | Persistent-TEE |
+|-------------|:---:|:---:|:---:|
+| Katana in provable mode | ✓ | ✓ | ✓ |
+| Piltover contract deployed | ✓ | — | ✓ |
+| Settlement account (L2) | ✓ | — | ✓ |
+| Atlantic API key | ✓ | ✓ | — |
+| `layout_bridge` program | ✓ | ✓ | — |
+| Katana-TEE node | — | — | ✓ |
+| TEE registry contract | — | — | ✓ |
+| Prover network account | — | — | ✓ |
+| Celestia light node | — | ✓ | — |
+
+---
+
+## Setup
+
+These are one-time steps before running Saya.
+
+### 1. Deploy Piltover (`ops`)
+
+Set environment variables:
 
 ```bash
 export SETTLEMENT_ACCOUNT_PRIVATE_KEY=<PRIVATE_KEY_IN_HEX>
 export SETTLEMENT_ACCOUNT_ADDRESS=<ACCOUNT_ADDRESS_IN_HEX>
 export SETTLEMENT_CHAIN_ID=<sepolia|mainnet|CUSTOM_CHAIN_ID>
+# SETTLEMENT_RPC_URL is optional for sepolia/mainnet (default public RPC is used)
 ```
 
-`SETTLEMENT_RPC_URL` is optional — if `SETTLEMENT_CHAIN_ID` is `sepolia` or `mainnet` the default public RPC is used automatically.
-
-### Declare the core contract
+Then declare, deploy, and configure the contract:
 
 ```bash
-cargo run --manifest-path bin/ops/Cargo.toml -- core-contract declare
-```
-
-Or with a custom contract path:
-
-```bash
-cargo run --manifest-path bin/ops/Cargo.toml -- core-contract declare --core-contract-path <PATH>
-```
-
-Expected output for the unmodified core contract:
-
-```
-[INFO  saya::core_contract::utils] Core contract already declared on-chain.
-[INFO  saya::core_contract::cli] Core contract class hash: 0x5aed647bf20ab45d4ca041823019ab1f98425eba797ce6b998af94237677f5
-```
-
-### Deploy the core contract
-
-```bash
-cargo run --manifest-path bin/ops/Cargo.toml -- core-contract deploy --salt 0x5
-```
-
-The output contains two important values — **block number** and **contract address** — save them for future use:
-
-```
-[INFO  saya::core_contract::utils] Core contract deployed.
-[INFO  saya::core_contract::utils]  Tx hash   : 0x5bfedaba61dcebb3ab0a8f5856eace3a6bec17f007654142f5004b0ef4f39bf
-[INFO  saya::core_contract::utils]  Deployed on block  : 6180778
-[INFO  saya::core_contract::cli] Core contract address: 0x9da87cf1e8ceccb46e7d044541b51bc7f369c262f332e49152e74b30659b53
-```
-
-Options:
-
-```
---class-hash <CLASS_HASH>  [env: CLASS_HASH=]  [default: latest Piltover hash]
---salt <SALT>              [env: SALT=]
-```
-
-### Set program info and fact registry
-
-```bash
-cargo run --manifest-path bin/ops/Cargo.toml -- core-contract setup-program \
-  --core-contract-address 0x9da87cf1e8ceccb46e7d044541b51bc7f369c262f332e49152e74b30659b53 \
+saya-ops core-contract declare
+saya-ops core-contract deploy --salt 0x5
+saya-ops core-contract setup-program \
+  --core-contract-address <ADDRESS_FROM_DEPLOY> \
   --chain-id example-chain
 ```
 
-Options:
+The `deploy` command prints the **contract address** and **deployed block number** — save both for the next step.
 
-```
---fact-registry-address <FACT_REGISTRY_ADDRESS>  [env: FACT_REGISTRY_ADDRESS=]
---core-contract-address <CORE_CONTRACT_ADDRESS>  [env: CORE_CONTRACT_ADDRESS=]
---fee-token-address <FEE_TOKEN_ADDRESS>          [env: FEE_TOKEN_ADDRESS=]
---chain-id <CHAIN_ID>                            [env: CHAIN_ID=]
-```
+> For local testing without real proofs, deploy a mock fact registry instead:
+> ```bash
+> saya-ops core-contract declare-and-deploy-fact-registry-mock --salt 0x1
+> # then pass --fact-registry-address <MOCK_ADDRESS> to setup-program
+> ```
 
-### Deploy a mock fact registry (for testing)
+### 2. Initialize Katana
 
-Deploys a fact registry that confirms any submitted fact — useful for local testing without real proofs:
-
-```bash
-cargo run --manifest-path bin/ops/Cargo.toml -- core-contract declare-and-deploy-fact-registry-mock --salt 0x1
-```
-
-Then pass the deployed address to `setup-program --fact-registry-address`.
-
----
-
-## Initialize Katana
-
-`katana init` generates a configuration file and genesis block:
+Katana must run in **provable mode** (supported from Dojo `1.3.0`, Starknet v14.0.1 only).
 
 ```bash
 katana init \
   --settlement-chain sepolia \
   --id example-chain \
-  --settlement-contract 0x9da87cf1e8ceccb46e7d044541b51bc7f369c262f332e49152e74b30659b53 \
-  --settlement-contract-deployed-block 6180778
+  --settlement-contract <PILTOVER_ADDRESS> \
+  --settlement-contract-deployed-block <DEPLOYED_BLOCK>
 ```
 
-Use `katana config` to list local configurations.
-
-Start Katana with:
+Start Katana with a block time (required for provable mode — Katana never produces empty blocks):
 
 ```bash
-katana --chain <CHAIN_ID> --block-time 30000
+katana --chain example-chain --block-time 30000
 ```
 
-> **Note:** When running Katana in provable mode it is recommended to set a block time (in milliseconds). Katana starts the block timer on the first transaction in a block and never produces empty blocks.
+### 3. Get Cairo programs (persistent mode only)
 
-> **Note:** Use `--output-path` with `katana init` to write config to a custom directory, then start with `--chain /path`.
-
----
-
-## Requirements
-
-- Katana running in provable mode.
-
-### Persistent mode
-
-- Piltover settlement contract deployed on the settlement chain (via `ops core-contract` above, or `katana init`).
-- An account on the settlement chain with funds to submit settlement transactions.
-- Herodotus Atlantic API key (from <https://herodotus.cloud>) unless using `--mock-layout-bridge-program-hash`.
-
-### Persistent-TEE mode
-
-- Katana TEE node (via `katana-tee`) running and reachable.
-- TEE registry contract deployed on the prover network.
-- An account on the prover network for submitting proofs.
-- An account on the settlement chain with funds to submit settlement transactions.
-
-### Sovereign mode
-
-- Celestia light node running with a funded account for blob submission. A helper script is available at `scripts/celestia.sh`.
-
----
-
-## Cairo programs
-
-Persistent mode requires a compiled `layout_bridge` Cairo program:
+The `layout_bridge` program ships with the release. Download it from the [releases page](https://github.com/dojoengine/saya/releases) or build it locally:
 
 ```bash
 ./scripts/generate_layout_bridge.sh
+# Requires Docker (linux/amd64 only — emulation needs ~32 GB RAM)
 ```
-
-The script requires Docker. Set `SUDO` if needed:
-
-```bash
-SUDO=sudo ./scripts/generate_layout_bridge.sh
-```
-
-> **Note:** The `starknet/cairo-lang` Docker image is `linux/amd64` only — emulation requires ~32 GB RAM.
-
-> **Note:** Pre-built programs are available in the Saya Docker image at `/programs` and on the [Saya release page](https://github.com/dojoengine/saya/releases).
 
 ---
 
-## Persistent mode
+## Running
 
-### Running
+### Persistent mode
 
 ```bash
-cargo run --manifest-path bin/persistent/Cargo.toml -r -- start \
+saya start \
   --rollup-rpc http://localhost:5050 \
   --settlement-rpc https://starknet-sepolia.public.blastapi.io \
   --settlement-piltover-address <PILTOVER_ADDRESS> \
@@ -209,7 +129,8 @@ cargo run --manifest-path bin/persistent/Cargo.toml -r -- start \
   --settlement-integrity-address <INTEGRITY_ADDRESS>
 ```
 
-Key options:
+<details>
+<summary>All options</summary>
 
 ```
 --rollup-rpc <URL>                           Katana L3 JSON-RPC endpoint
@@ -222,57 +143,27 @@ Key options:
 --settlement-integrity-address <FELT>        On-chain integrity/fact registry address
 --blocks-processed-in-parallel <N>           Parallel block pipeline depth (default: 60)
 --db-dir <PATH>                              SQLite database directory
+--mock-layout-bridge-program-hash <HASH>     Skip real Atlantic proving (testing only)
+--mock-snos-from-pie                         Derive SNOS proof from PIE (testing only)
 ```
 
-### Mocking proofs (for testing)
+</details>
 
-Replace the layout bridge proof with a mock (skips on-chain fact registration) by first switching Piltover to a mock fact registry:
-
-```bash
-cargo run --manifest-path bin/ops/Cargo.toml -- core-contract setup-program \
-  --core-contract-address <PILTOVER_ADDRESS> \
-  --chain-id example-chain \
-  --fact-registry-address <MOCK_FACT_REGISTRY_ADDRESS>
-```
-
-Then start with:
+### Sovereign mode
 
 ```bash
-cargo run --manifest-path bin/persistent/Cargo.toml -r -- start \
-  ... \
-  --mock-layout-bridge-program-hash 0x43c5c4cc37c4614d2cf3a833379052c3a38cd18d688b617e2c720e8f941cb8
-```
-
-To also mock the SNOS proof (derives it from the PIE):
-
-```bash
-cargo run --manifest-path bin/persistent/Cargo.toml -r -- start \
-  ... \
-  --mock-layout-bridge-program-hash 0x43c5c4cc37c4614d2cf3a833379052c3a38cd18d688b617e2c720e8f941cb8 \
-  --mock-snos-from-pie
-```
-
----
-
-## Sovereign mode
-
-```bash
-cargo run --manifest-path bin/persistent/Cargo.toml -r -- sovereign start \
+saya sovereign start \
   --rollup-rpc http://localhost:5050 \
   --celestia-rpc http://localhost:26658 \
   --celestia-token <TOKEN>
 ```
 
----
+A helper script for running a local Celestia light node is at `scripts/celestia.sh`.
 
-## Persistent-TEE mode
-
-The TEE pipeline ingests blocks from Katana, fetches an AMD SEV-SNP attestation quote, generates an SP1 Groth16 proof via the TEE registry, and settles on Piltover.
-
-### Running
+### Persistent-TEE mode
 
 ```bash
-cargo run --manifest-path bin/persistent-tee/Cargo.toml -r -- tee start \
+saya-tee tee start \
   --rollup-rpc http://localhost:5050 \
   --settlement-rpc https://starknet-sepolia.public.blastapi.io \
   --settlement-piltover-address <PILTOVER_ADDRESS> \
@@ -282,7 +173,8 @@ cargo run --manifest-path bin/persistent-tee/Cargo.toml -r -- tee start \
   --prover-private-key <PROVER_PRIVATE_KEY>
 ```
 
-Key options:
+<details>
+<summary>All options</summary>
 
 ```
 --rollup-rpc <URL>                       Katana TEE node JSON-RPC endpoint
@@ -296,6 +188,23 @@ Key options:
 --idle-timeout-secs <N>                  Flush partial batch after N idle seconds (default: 120)
 --attestor-poll-interval-ms <N>          Attestor poll interval in ms (default: 1000)
 --db-dir <PATH>                          SQLite database directory
+```
+
+</details>
+
+---
+
+## Building from source
+
+Only needed if you want to modify Saya.
+Requires Rust `1.89` — install via [rustup](https://rustup.rs); `rust-toolchain.toml` pins the version automatically.
+
+```bash
+cd bin/persistent && cargo build --release
+cd bin/ops && cargo build --release
+
+# TEE mode (requires SSH access to cartridge-gg/katana-tee)
+cd bin/persistent-tee && cargo build --release
 ```
 
 ---

--- a/bin/ops/Cargo.lock
+++ b/bin/ops/Cargo.lock
@@ -3606,27 +3606,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "ops"
-version = "0.3.1"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "cairo-lang-starknet-classes",
- "celestia-rpc",
- "celestia-types",
- "clap",
- "dojo-utils",
- "env_logger",
- "hex",
- "log",
- "serde_json",
- "starknet",
- "starknet_api",
- "tokio",
- "url",
-]
-
-[[package]]
 name = "parity-scale-codec"
 version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4489,6 +4468,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "saya-ops"
+version = "0.3.1"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "cairo-lang-starknet-classes",
+ "celestia-rpc",
+ "celestia-types",
+ "clap",
+ "dojo-utils",
+ "env_logger",
+ "hex",
+ "log",
+ "serde_json",
+ "starknet",
+ "starknet_api",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/bin/ops/Cargo.toml
+++ b/bin/ops/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/dojoengine/saya"
 [workspace.dependencies]
 
 [package]
-name = "ops"
+name = "saya-ops"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/bin/persistent-tee/Cargo.toml
+++ b/bin/persistent-tee/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/dojoengine/saya"
 [workspace.dependencies]
 
 [package]
-name = "persistent-tee"
+name = "saya-tee"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/bin/persistent/Cargo.lock
+++ b/bin/persistent/Cargo.lock
@@ -5074,45 +5074,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "persistent"
-version = "0.3.1"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "bigdecimal",
- "cainome",
- "cairo-vm",
- "ciborium",
- "clap",
- "env_logger",
- "futures-util",
- "generate-pie",
- "hex",
- "integrity",
- "log",
- "num-traits",
- "piltover 0.1.0 (git+https://github.com/cartridge-gg/piltover.git?rev=67e65b8928b7ee3c2c188bf36c6b9eddc14addb2)",
- "reqwest 0.12.23",
- "saya-core",
- "serde",
- "serde_json",
- "starknet",
- "starknet-crypto 0.8.1",
- "starknet-types-core 0.2.4",
- "starknet_api",
- "swiftness",
- "swiftness_air",
- "swiftness_commitment",
- "swiftness_fri",
- "swiftness_pow",
- "swiftness_stark",
- "thiserror 2.0.16",
- "tokio",
- "url",
- "zip 2.4.2",
-]
-
-[[package]]
 name = "petgraph"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6172,6 +6133,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "saya"
+version = "0.3.1"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bigdecimal",
+ "cainome",
+ "cairo-vm",
+ "ciborium",
+ "clap",
+ "env_logger",
+ "futures-util",
+ "generate-pie",
+ "hex",
+ "integrity",
+ "log",
+ "num-traits",
+ "piltover 0.1.0 (git+https://github.com/cartridge-gg/piltover.git?rev=67e65b8928b7ee3c2c188bf36c6b9eddc14addb2)",
+ "reqwest 0.12.23",
+ "saya-core",
+ "serde",
+ "serde_json",
+ "starknet",
+ "starknet-crypto 0.8.1",
+ "starknet-types-core 0.2.4",
+ "starknet_api",
+ "swiftness",
+ "swiftness_air",
+ "swiftness_commitment",
+ "swiftness_fri",
+ "swiftness_pow",
+ "swiftness_stark",
+ "thiserror 2.0.16",
+ "tokio",
+ "url",
+ "zip 2.4.2",
 ]
 
 [[package]]

--- a/bin/persistent/Cargo.toml
+++ b/bin/persistent/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/dojoengine/saya"
 [workspace.dependencies]
 
 [package]
-name = "persistent"
+name = "saya"
 version.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Rename Cargo packages and release artifacts from internal names (persistent, ops, persistent-tee) to user-facing command names. Update Dockerfiles, release workflow, and README accordingly.