### PR TITLE
feat(ops): structured `--output json` for core-contract subcommands

### DIFF
--- a/bin/ops/Cargo.lock
+++ b/bin/ops/Cargo.lock
@@ -4484,6 +4484,7 @@ dependencies = [
  "env_logger",
  "hex",
  "log",
+ "serde",
  "serde_json",
  "starknet",
  "starknet_api",

--- a/bin/ops/Cargo.toml
+++ b/bin/ops/Cargo.toml
@@ -31,6 +31,7 @@ clap = { version = "4.5.23", default-features = false, features = [
 dojo-utils = { git = "https://github.com/dojoengine/dojo", branch = "main" }
 env_logger = { version = "0.11.6", features = ["unstable-kv"] }
 log = { version = "0.4.22", features = ["kv"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.134", default-features = false }
 starknet = { git = "https://github.com/dojoengine/starknet-rs", branch = "feat/types-rs-100-blake2s" }
 starknet_api = { git = "https://github.com/karnotxyz/sequencer", rev = "e04617e0581d5ec93a035ec0e15419b4c201b629" }

--- a/bin/ops/src/core_contract/cli.rs
+++ b/bin/ops/src/core_contract/cli.rs
@@ -13,7 +13,7 @@ use crate::core_contract::utils::{
 use anyhow::Result;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use dojo_utils::TransactionResult;
-use log::info;
+use log::debug;
 use serde::Serialize;
 use starknet::core::types::Felt;
 use starknet::core::utils::cairo_short_string_to_felt;
@@ -256,7 +256,6 @@ impl CoreContract {
                     .await?
                 };
 
-                info!("Core contract class hash: {:?}", class_hash);
                 let (tx_hash, declared_block) = tx_outcome(&tx);
                 CoreContractResult::Declare {
                     class_hash: fhex(class_hash),
@@ -273,7 +272,6 @@ impl CoreContract {
                 )
                 .await?;
 
-                info!("Core contract address: {:?}", contract_address);
                 let (tx_hash, deployed_block) = tx_outcome(&tx);
                 CoreContractResult::Deploy {
                     class_hash: fhex(deploy_args.class_hash),
@@ -307,7 +305,6 @@ impl CoreContract {
                 )
                 .await?;
 
-                info!("Fact registry mock address: {:?}", fact_registry_address);
                 let (tx_hash, deployed_block) = tx_outcome(&deploy_tx);
                 CoreContractResult::DeclareAndDeployFactRegistryMock {
                     class_hash: fhex(class_hash),
@@ -340,7 +337,6 @@ impl CoreContract {
                 )
                 .await?;
 
-                info!("TEE registry mock address: {:?}", tee_registry_address);
                 let (tx_hash, deployed_block) = tx_outcome(&deploy_tx);
                 CoreContractResult::DeclareAndDeployTeeRegistryMock {
                     class_hash: fhex(class_hash),
@@ -355,7 +351,7 @@ impl CoreContract {
 
                 let snos_config_hash =
                     compute_starknet_os_config_hash(chain_id, setup_program_args.fee_token_address);
-                info!("Starknet OS config hash: {:?}", snos_config_hash);
+                debug!("Starknet OS config hash: {:?}", snos_config_hash);
                 let set_program_tx = set_program_info(
                     account.clone(),
                     setup_program_args.core_contract_address,
@@ -364,14 +360,14 @@ impl CoreContract {
                 .await?;
                 let fact_registry =
                     self.get_fact_registry_address(setup_program_args.fact_registry_address);
-                info!("Set program info transaction submitted: {:?}", set_program_tx);
+                debug!("Set program info transaction submitted: {:?}", set_program_tx);
                 let set_fact_tx = set_fact_registry(
                     account.clone(),
                     setup_program_args.core_contract_address,
                     fact_registry,
                 )
                 .await?;
-                info!("Fact registry set transaction submitted: {:?}", set_fact_tx);
+                debug!("Fact registry set transaction submitted: {:?}", set_fact_tx);
                 let (spi_tx_hash, spi_block) = tx_outcome(&set_program_tx);
                 let (sfr_tx_hash, sfr_block) = tx_outcome(&set_fact_tx);
                 CoreContractResult::SetupProgram {
@@ -386,11 +382,37 @@ impl CoreContract {
             }
         };
 
-        // Emit structured result to stdout in JSON mode. Human logs stay on
-        // stderr via env_logger; the two streams don't interfere, so
-        // downstream can redirect/parse each independently.
-        if self.output == OutputFormat::Json {
-            println!("{}", serde_json::to_string(&result)?);
+        // stdout is reserved for the primary command result. Human-readable
+        // progress/diagnostic logs stay on stderr via env_logger (`debug!`
+        // and `trace!`), so the two streams are independently pipeable.
+        //
+        // `--output json`  → one JSON object per invocation.
+        // `--output text`  → a single hex string (class hash or contract
+        //                    address), or nothing at all for action-only
+        //                    subcommands like `setup-program`.
+        match self.output {
+            OutputFormat::Json => {
+                println!("{}", serde_json::to_string(&result)?);
+            }
+            OutputFormat::Text => match &result {
+                CoreContractResult::Declare { class_hash, .. } => println!("{}", class_hash),
+                CoreContractResult::Deploy {
+                    contract_address, ..
+                } => println!("{}", contract_address),
+                CoreContractResult::DeclareAndDeployFactRegistryMock {
+                    contract_address,
+                    ..
+                } => println!("{}", contract_address),
+                CoreContractResult::DeclareAndDeployTeeRegistryMock {
+                    contract_address,
+                    ..
+                } => println!("{}", contract_address),
+                CoreContractResult::SetupProgram { .. } => {
+                    // Action, not query: success is implied by a zero exit
+                    // code. Users who want the tx hashes can request them
+                    // with `--output json`.
+                }
+            },
         }
 
         Ok(())

--- a/bin/ops/src/core_contract/cli.rs
+++ b/bin/ops/src/core_contract/cli.rs
@@ -11,14 +11,31 @@ use crate::core_contract::utils::{
     deploy_contract, deploy_core_contract, set_fact_registry, set_program_info,
 };
 use anyhow::Result;
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use dojo_utils::TransactionResult;
 use log::info;
+use serde::Serialize;
 use starknet::core::types::Felt;
 use starknet::core::utils::cairo_short_string_to_felt;
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::{JsonRpcClient, Provider};
 use starknet::signers::{LocalWallet, SigningKey};
 use url::Url;
+
+/// Output format for the final result of a subcommand.
+///
+/// `Text` (the default) keeps the current behavior: human-readable `info!` logs
+/// on stderr, nothing special on stdout.
+///
+/// `Json` additionally emits a single JSON object to stdout with the structured
+/// result of the command (addresses, tx hashes, block numbers). Human logs
+/// remain on stderr unchanged, so the stdout stream is safe to pipe into `jq`.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub enum OutputFormat {
+    #[default]
+    Text,
+    Json,
+}
 
 /// Supported settlement chain options for rollup initialization.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -51,6 +68,73 @@ pub struct CoreContract {
     settlement_rpc_url: Option<Url>,
     #[clap(long, env = "SETTLEMENT_CHAIN_ID")]
     settlement_chain_id: SettlementChain,
+    /// Output format for the structured result (`text` or `json`). See
+    /// [`OutputFormat`]. `--output json` pipes one JSON object to stdout
+    /// suitable for `jq`; all human logs stay on stderr.
+    #[clap(long, value_enum, default_value_t = OutputFormat::Text, env = "SAYA_OPS_OUTPUT")]
+    output: OutputFormat,
+}
+
+/// Structured result of a `core-contract` subcommand, emitted to stdout when
+/// `--output json` is set. Downstream orchestrators (docker-compose init
+/// containers, terraform external providers, CI scripts) consume this in place
+/// of parsing `info!` log lines.
+///
+/// Felts are rendered as `0x`-prefixed lowercase hex strings. `tx_hash` and
+/// `deployed_block` are `null` when the underlying operation was a no-op (e.g.
+/// the contract was already declared or deployed at the same salt).
+#[derive(Debug, Serialize)]
+#[serde(tag = "command", rename_all = "kebab-case")]
+pub enum CoreContractResult {
+    Declare {
+        class_hash: String,
+        tx_hash: Option<String>,
+        declared_block: Option<u64>,
+    },
+    Deploy {
+        class_hash: String,
+        contract_address: String,
+        salt: String,
+        tx_hash: Option<String>,
+        deployed_block: Option<u64>,
+    },
+    DeclareAndDeployFactRegistryMock {
+        class_hash: String,
+        contract_address: String,
+        salt: String,
+        tx_hash: Option<String>,
+        deployed_block: Option<u64>,
+    },
+    DeclareAndDeployTeeRegistryMock {
+        class_hash: String,
+        contract_address: String,
+        salt: String,
+        tx_hash: Option<String>,
+        deployed_block: Option<u64>,
+    },
+    SetupProgram {
+        core_contract_address: String,
+        snos_config_hash: String,
+        fact_registry_address: String,
+        set_program_info_tx: Option<String>,
+        set_program_info_block: Option<u64>,
+        set_fact_registry_tx: Option<String>,
+        set_fact_registry_block: Option<u64>,
+    },
+}
+
+fn fhex(f: Felt) -> String {
+    format!("{:#x}", f)
+}
+
+fn tx_outcome(r: &TransactionResult) -> (Option<String>, Option<u64>) {
+    match r {
+        TransactionResult::Noop => (None, None),
+        TransactionResult::Hash(h) => (Some(fhex(*h)), None),
+        TransactionResult::HashReceipt(h, receipt) => {
+            (Some(fhex(*h)), Some(receipt.block.block_number()))
+        }
+    }
 }
 
 #[derive(Debug, Subcommand)]
@@ -159,9 +243,9 @@ impl CoreContract {
             chain_id,
             encoding,
         );
-        match self.cmd {
+        let result = match self.cmd {
             CoreContractCmd::Declare(declare_args) => {
-                let class_hash = if let Some(path) = declare_args.core_contract_path {
+                let (class_hash, tx) = if let Some(path) = declare_args.core_contract_path {
                     declare_contract(account.clone(), "Core contract", Path::new(&path)).await?
                 } else {
                     declare_contract_from_bytes(
@@ -173,9 +257,15 @@ impl CoreContract {
                 };
 
                 info!("Core contract class hash: {:?}", class_hash);
+                let (tx_hash, declared_block) = tx_outcome(&tx);
+                CoreContractResult::Declare {
+                    class_hash: fhex(class_hash),
+                    tx_hash,
+                    declared_block,
+                }
             }
             CoreContractCmd::Deploy(deploy_args) => {
-                let contract_address = deploy_core_contract(
+                let (contract_address, tx) = deploy_core_contract(
                     account.clone(),
                     "Core contract",
                     deploy_args.class_hash,
@@ -184,9 +274,19 @@ impl CoreContract {
                 .await?;
 
                 info!("Core contract address: {:?}", contract_address);
+                let (tx_hash, deployed_block) = tx_outcome(&tx);
+                CoreContractResult::Deploy {
+                    class_hash: fhex(deploy_args.class_hash),
+                    contract_address: fhex(contract_address),
+                    salt: fhex(deploy_args.salt),
+                    tx_hash,
+                    deployed_block,
+                }
             }
             CoreContractCmd::DeclareAndDeployFactRegistryMock(deploy_fact_registry_args) => {
-                let class_hash = if let Some(path) = deploy_fact_registry_args.fact_registry_path {
+                let (class_hash, _declare_tx) = if let Some(path) =
+                    deploy_fact_registry_args.fact_registry_path
+                {
                     declare_contract(account.clone(), "Fact registry mock", Path::new(&path))
                         .await?
                 } else {
@@ -198,7 +298,7 @@ impl CoreContract {
                     .await?
                 };
 
-                let fact_registry_address = deploy_contract(
+                let (fact_registry_address, deploy_tx) = deploy_contract(
                     account.clone(),
                     "Fact registry mock",
                     class_hash,
@@ -208,20 +308,30 @@ impl CoreContract {
                 .await?;
 
                 info!("Fact registry mock address: {:?}", fact_registry_address);
+                let (tx_hash, deployed_block) = tx_outcome(&deploy_tx);
+                CoreContractResult::DeclareAndDeployFactRegistryMock {
+                    class_hash: fhex(class_hash),
+                    contract_address: fhex(fact_registry_address),
+                    salt: fhex(deploy_fact_registry_args.salt),
+                    tx_hash,
+                    deployed_block,
+                }
             }
             CoreContractCmd::DeclareAndDeployTeeRegistryMock(deploy_tee_registry_args) => {
-                let class_hash = if let Some(path) = deploy_tee_registry_args.tee_registry_path {
-                    declare_contract(account.clone(), "TEE registry mock", Path::new(&path)).await?
-                } else {
-                    declare_contract_from_bytes(
-                        account.clone(),
-                        "TEE registry mock",
-                        TEE_REGISTRY_MOCK_BYTES,
-                    )
-                    .await?
-                };
+                let (class_hash, _declare_tx) =
+                    if let Some(path) = deploy_tee_registry_args.tee_registry_path {
+                        declare_contract(account.clone(), "TEE registry mock", Path::new(&path))
+                            .await?
+                    } else {
+                        declare_contract_from_bytes(
+                            account.clone(),
+                            "TEE registry mock",
+                            TEE_REGISTRY_MOCK_BYTES,
+                        )
+                        .await?
+                    };
 
-                let tee_registry_address = deploy_contract(
+                let (tee_registry_address, deploy_tx) = deploy_contract(
                     account.clone(),
                     "TEE registry mock",
                     class_hash,
@@ -231,6 +341,14 @@ impl CoreContract {
                 .await?;
 
                 info!("TEE registry mock address: {:?}", tee_registry_address);
+                let (tx_hash, deployed_block) = tx_outcome(&deploy_tx);
+                CoreContractResult::DeclareAndDeployTeeRegistryMock {
+                    class_hash: fhex(class_hash),
+                    contract_address: fhex(tee_registry_address),
+                    salt: fhex(deploy_tee_registry_args.salt),
+                    tx_hash,
+                    deployed_block,
+                }
             }
             CoreContractCmd::SetupProgram(ref setup_program_args) => {
                 let chain_id = cairo_short_string_to_felt(&setup_program_args.chain_id)?;
@@ -238,7 +356,7 @@ impl CoreContract {
                 let snos_config_hash =
                     compute_starknet_os_config_hash(chain_id, setup_program_args.fee_token_address);
                 info!("Starknet OS config hash: {:?}", snos_config_hash);
-                let tx_res = set_program_info(
+                let set_program_tx = set_program_info(
                     account.clone(),
                     setup_program_args.core_contract_address,
                     snos_config_hash,
@@ -246,15 +364,33 @@ impl CoreContract {
                 .await?;
                 let fact_registry =
                     self.get_fact_registry_address(setup_program_args.fact_registry_address);
-                info!("Set program info transaction submitted: {:?}", tx_res);
-                let tx_res = set_fact_registry(
+                info!("Set program info transaction submitted: {:?}", set_program_tx);
+                let set_fact_tx = set_fact_registry(
                     account.clone(),
                     setup_program_args.core_contract_address,
                     fact_registry,
                 )
                 .await?;
-                info!("Fact registry set transaction submitted: {:?}", tx_res);
+                info!("Fact registry set transaction submitted: {:?}", set_fact_tx);
+                let (spi_tx_hash, spi_block) = tx_outcome(&set_program_tx);
+                let (sfr_tx_hash, sfr_block) = tx_outcome(&set_fact_tx);
+                CoreContractResult::SetupProgram {
+                    core_contract_address: fhex(setup_program_args.core_contract_address),
+                    snos_config_hash: fhex(snos_config_hash),
+                    fact_registry_address: fhex(fact_registry),
+                    set_program_info_tx: spi_tx_hash,
+                    set_program_info_block: spi_block,
+                    set_fact_registry_tx: sfr_tx_hash,
+                    set_fact_registry_block: sfr_block,
+                }
             }
+        };
+
+        // Emit structured result to stdout in JSON mode. Human logs stay on
+        // stderr via env_logger; the two streams don't interfere, so
+        // downstream can redirect/parse each independently.
+        if self.output == OutputFormat::Json {
+            println!("{}", serde_json::to_string(&result)?);
         }
 
         Ok(())

--- a/bin/ops/src/core_contract/cli.rs
+++ b/bin/ops/src/core_contract/cli.rs
@@ -351,7 +351,7 @@ impl CoreContract {
 
                 let snos_config_hash =
                     compute_starknet_os_config_hash(chain_id, setup_program_args.fee_token_address);
-                debug!("Starknet OS config hash: {:?}", snos_config_hash);
+                debug!(snos_config_hash:? = snos_config_hash; "Computed Starknet OS config hash.");
                 let set_program_tx = set_program_info(
                     account.clone(),
                     setup_program_args.core_contract_address,
@@ -360,14 +360,14 @@ impl CoreContract {
                 .await?;
                 let fact_registry =
                     self.get_fact_registry_address(setup_program_args.fact_registry_address);
-                debug!("Set program info transaction submitted: {:?}", set_program_tx);
+                debug!(tx:? = set_program_tx; "set_program_info transaction submitted.");
                 let set_fact_tx = set_fact_registry(
                     account.clone(),
                     setup_program_args.core_contract_address,
                     fact_registry,
                 )
                 .await?;
-                debug!("Fact registry set transaction submitted: {:?}", set_fact_tx);
+                debug!(tx:? = set_fact_tx; "set_fact_registry transaction submitted.");
                 let (spi_tx_hash, spi_block) = tx_outcome(&set_program_tx);
                 let (sfr_tx_hash, sfr_block) = tx_outcome(&set_fact_tx);
                 CoreContractResult::SetupProgram {

--- a/bin/ops/src/core_contract/utils.rs
+++ b/bin/ops/src/core_contract/utils.rs
@@ -43,7 +43,20 @@ pub async fn declare_contract(
     let mut results = declarer.declare_all().await?;
     let tx_result = results.remove(0);
 
-    log_tx_result(&tx_result, contract_name, "declared", "Declared on block");
+    match &tx_result {
+        TransactionResult::Noop => {
+            debug!("Contract {} already declared.", contract_name);
+        }
+        TransactionResult::Hash(hash) => {
+            debug!("Contract {} declared.", contract_name);
+            trace!("  Tx hash  : {hash:?}");
+        }
+        TransactionResult::HashReceipt(hash, receipt) => {
+            debug!("Contract {} declared.", contract_name);
+            trace!("  Tx hash  : {hash:?}");
+            trace!("  Declared on block  : {}", receipt.block.block_number());
+        }
+    }
     Ok((class.class_hash, tx_result))
 }
 
@@ -65,39 +78,21 @@ pub async fn declare_contract_from_bytes(
     let mut results = declarer.declare_all().await?;
     let tx_result = results.remove(0);
 
-    log_tx_result(&tx_result, contract_name, "declared", "Declared on block");
-    Ok((class.class_hash, tx_result))
-}
-
-/// Centralized, leveled logger for `TransactionResult`. Primary result values
-/// (class hashes, contract addresses) go to stdout via `println!` in
-/// cli.rs; this function only emits diagnostic progress.
-///
-/// - `debug!` for status ("Contract X deployed", "Contract X already deployed")
-/// - `trace!` for low-level tx detail (hash, block number)
-///
-/// `verb_past` is e.g. "declared" or "deployed"; `block_label` is
-/// "Declared on block" or "At block".
-fn log_tx_result(
-    result: &TransactionResult,
-    contract_name: &str,
-    verb_past: &str,
-    block_label: &str,
-) {
-    match result {
+    match &tx_result {
         TransactionResult::Noop => {
-            debug!("Contract {} already {}.", contract_name, verb_past);
+            debug!("Contract {} already declared.", contract_name);
         }
         TransactionResult::Hash(hash) => {
-            debug!("Contract {} {}.", contract_name, verb_past);
+            debug!("Contract {} declared.", contract_name);
             trace!("  Tx hash  : {hash:?}");
         }
         TransactionResult::HashReceipt(hash, receipt) => {
-            debug!("Contract {} {}.", contract_name, verb_past);
+            debug!("Contract {} declared.", contract_name);
             trace!("  Tx hash  : {hash:?}");
-            trace!("  {}  : {}", block_label, receipt.block.block_number());
+            trace!("  Declared on block  : {}", receipt.block.block_number());
         }
     }
+    Ok((class.class_hash, tx_result))
 }
 
 pub async fn deploy_core_contract(
@@ -146,7 +141,20 @@ pub async fn deploy_contract(
         .await
     {
         Ok((contract_address, transaction_result)) => {
-            log_tx_result(&transaction_result, contract_name, "deployed", "At block");
+            match &transaction_result {
+                TransactionResult::Noop => {
+                    debug!("Contract {} already deployed.", contract_name);
+                }
+                TransactionResult::Hash(hash) => {
+                    debug!("Contract {} deployed.", contract_name);
+                    trace!("  Tx hash  : {hash:?}");
+                }
+                TransactionResult::HashReceipt(hash, receipt) => {
+                    debug!("Contract {} deployed.", contract_name);
+                    trace!("  Tx hash  : {hash:?}");
+                    trace!("  At block  : {}", receipt.block.block_number());
+                }
+            }
             Ok((contract_address, transaction_result))
         }
         Err(e) => {

--- a/bin/ops/src/core_contract/utils.rs
+++ b/bin/ops/src/core_contract/utils.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet_classes::contract_class::ContractClass;
 use dojo_utils::{Declarer, Deployer, Invoker, LabeledClass, TransactionResult, TxnConfig};
-use log::{info, warn};
+use log::{debug, trace, warn};
 use starknet::accounts::{Account, SingleOwnerAccount};
 use starknet::core::crypto::compute_hash_on_elements;
 use starknet::core::types::{contract::SierraClass, Call, Felt, FlattenedSierraClass};
@@ -43,20 +43,7 @@ pub async fn declare_contract(
     let mut results = declarer.declare_all().await?;
     let tx_result = results.remove(0);
 
-    match &tx_result {
-        TransactionResult::Noop => {
-            info!("Contract {} already declared.", contract_name);
-        }
-        TransactionResult::Hash(hash) => {
-            info!("Contract {} declared.", contract_name);
-            info!("  Tx hash   : {hash:?}");
-        }
-        TransactionResult::HashReceipt(hash, receipt) => {
-            info!("Contract {} declared.", contract_name);
-            info!("  Tx hash   : {hash:?}");
-            info!(" Declared on block  : {:?}", receipt.block.block_number());
-        }
-    };
+    log_tx_result(&tx_result, contract_name, "declared", "Declared on block");
     Ok((class.class_hash, tx_result))
 }
 
@@ -78,21 +65,39 @@ pub async fn declare_contract_from_bytes(
     let mut results = declarer.declare_all().await?;
     let tx_result = results.remove(0);
 
-    match &tx_result {
+    log_tx_result(&tx_result, contract_name, "declared", "Declared on block");
+    Ok((class.class_hash, tx_result))
+}
+
+/// Centralized, leveled logger for `TransactionResult`. Primary result values
+/// (class hashes, contract addresses) go to stdout via `println!` in
+/// cli.rs; this function only emits diagnostic progress.
+///
+/// - `debug!` for status ("Contract X deployed", "Contract X already deployed")
+/// - `trace!` for low-level tx detail (hash, block number)
+///
+/// `verb_past` is e.g. "declared" or "deployed"; `block_label` is
+/// "Declared on block" or "At block".
+fn log_tx_result(
+    result: &TransactionResult,
+    contract_name: &str,
+    verb_past: &str,
+    block_label: &str,
+) {
+    match result {
         TransactionResult::Noop => {
-            info!("Contract {} already declared.", contract_name);
+            debug!("Contract {} already {}.", contract_name, verb_past);
         }
         TransactionResult::Hash(hash) => {
-            info!("Contract {} declared.", contract_name);
-            info!("  Tx hash   : {hash:?}");
+            debug!("Contract {} {}.", contract_name, verb_past);
+            trace!("  Tx hash  : {hash:?}");
         }
         TransactionResult::HashReceipt(hash, receipt) => {
-            info!("Contract {} declared.", contract_name);
-            info!("  Tx hash   : {hash:?}");
-            info!(" Declared on block  : {:?}", receipt.block.block_number());
+            debug!("Contract {} {}.", contract_name, verb_past);
+            trace!("  Tx hash  : {hash:?}");
+            trace!("  {}  : {}", block_label, receipt.block.block_number());
         }
-    };
-    Ok((class.class_hash, tx_result))
+    }
 }
 
 pub async fn deploy_core_contract(
@@ -141,20 +146,7 @@ pub async fn deploy_contract(
         .await
     {
         Ok((contract_address, transaction_result)) => {
-            match &transaction_result {
-                TransactionResult::Noop => {
-                    info!("Contract {} already deployed.", contract_name);
-                }
-                TransactionResult::Hash(hash) => {
-                    info!("Contract {} deployed.", contract_name);
-                    info!("Tx hash   : {hash:?}");
-                }
-                TransactionResult::HashReceipt(hash, receipt) => {
-                    info!("Contract {} deployed.", contract_name);
-                    info!("Tx hash   : {hash:?}");
-                    info!("At block  : {:?}", receipt.block.block_number());
-                }
-            }
+            log_tx_result(&transaction_result, contract_name, "deployed", "At block");
             Ok((contract_address, transaction_result))
         }
         Err(e) => {

--- a/bin/ops/src/core_contract/utils.rs
+++ b/bin/ops/src/core_contract/utils.rs
@@ -29,7 +29,7 @@ pub async fn declare_contract(
     account: SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
     contract_name: &str,
     contract_path: &Path,
-) -> Result<Felt> {
+) -> Result<(Felt, TransactionResult)> {
     let txn_config = TxnConfig::default();
 
     let mut declarer = Declarer::new(account, txn_config);
@@ -40,9 +40,10 @@ pub async fn declare_contract(
         class: class.class.clone(),
     };
     declarer.add_class(labeled);
-    let results = declarer.declare_all().await?;
+    let mut results = declarer.declare_all().await?;
+    let tx_result = results.remove(0);
 
-    match &results[0] {
+    match &tx_result {
         TransactionResult::Noop => {
             info!("Contract {} already declared.", contract_name);
         }
@@ -56,14 +57,14 @@ pub async fn declare_contract(
             info!(" Declared on block  : {:?}", receipt.block.block_number());
         }
     };
-    Ok(class.class_hash)
+    Ok((class.class_hash, tx_result))
 }
 
 pub async fn declare_contract_from_bytes(
     account: SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
     contract_name: &str,
     contract_bytes: &[u8],
-) -> Result<Felt> {
+) -> Result<(Felt, TransactionResult)> {
     let txn_config = TxnConfig::default();
 
     let mut declarer = Declarer::new(account, txn_config);
@@ -74,9 +75,10 @@ pub async fn declare_contract_from_bytes(
         class: class.class.clone(),
     };
     declarer.add_class(labeled);
-    let results = declarer.declare_all().await?;
+    let mut results = declarer.declare_all().await?;
+    let tx_result = results.remove(0);
 
-    match &results[0] {
+    match &tx_result {
         TransactionResult::Noop => {
             info!("Contract {} already declared.", contract_name);
         }
@@ -90,7 +92,7 @@ pub async fn declare_contract_from_bytes(
             info!(" Declared on block  : {:?}", receipt.block.block_number());
         }
     };
-    Ok(class.class_hash)
+    Ok((class.class_hash, tx_result))
 }
 
 pub async fn deploy_core_contract(
@@ -98,7 +100,7 @@ pub async fn deploy_core_contract(
     contract_name: &str,
     class_hash: Felt,
     salt: Felt,
-) -> Result<Felt> {
+) -> Result<(Felt, TransactionResult)> {
     let constructor_calldata: Vec<Felt> = vec![
         // owner.
         account.address(),
@@ -126,7 +128,7 @@ pub async fn deploy_contract(
     class_hash: Felt,
     salt: Felt,
     constructor_calldata: &[Felt],
-) -> Result<Felt> {
+) -> Result<(Felt, TransactionResult)> {
     let txn_config = dojo_utils::TxnConfig {
         receipt: true,
         ..Default::default()
@@ -139,7 +141,7 @@ pub async fn deploy_contract(
         .await
     {
         Ok((contract_address, transaction_result)) => {
-            match transaction_result {
+            match &transaction_result {
                 TransactionResult::Noop => {
                     info!("Contract {} already deployed.", contract_name);
                 }
@@ -153,7 +155,7 @@ pub async fn deploy_contract(
                     info!("At block  : {:?}", receipt.block.block_number());
                 }
             }
-            Ok(contract_address)
+            Ok((contract_address, transaction_result))
         }
         Err(e) => {
             let address = try_extract_already_deployed_address(&e)?;
@@ -162,7 +164,10 @@ pub async fn deploy_contract(
                     "{} already deployed at address: {:?}",
                     contract_name, address
                 );
-                return Ok(address);
+                // Match the "already declared" semantics: represent an
+                // idempotent no-op with TransactionResult::Noop so the
+                // caller can serialize it uniformly.
+                return Ok((address, TransactionResult::Noop));
             }
             Err(anyhow!("{} deployment failed: {:?}", contract_name, e))
         }

--- a/bin/ops/src/core_contract/utils.rs
+++ b/bin/ops/src/core_contract/utils.rs
@@ -45,16 +45,15 @@ pub async fn declare_contract(
 
     match &tx_result {
         TransactionResult::Noop => {
-            debug!("Contract {} already declared.", contract_name);
+            debug!(contract:% = contract_name; "Contract already declared.");
         }
         TransactionResult::Hash(hash) => {
-            debug!("Contract {} declared.", contract_name);
-            trace!("  Tx hash  : {hash:?}");
+            debug!(contract:% = contract_name; "Contract declared.");
+            trace!(tx_hash:? = hash; "Tx hash");
         }
         TransactionResult::HashReceipt(hash, receipt) => {
-            debug!("Contract {} declared.", contract_name);
-            trace!("  Tx hash  : {hash:?}");
-            trace!("  Declared on block  : {}", receipt.block.block_number());
+            debug!(contract:% = contract_name; "Contract declared.");
+            trace!(tx_hash:? = hash, block = receipt.block.block_number(); "Declared on block");
         }
     }
     Ok((class.class_hash, tx_result))
@@ -80,16 +79,15 @@ pub async fn declare_contract_from_bytes(
 
     match &tx_result {
         TransactionResult::Noop => {
-            debug!("Contract {} already declared.", contract_name);
+            debug!(contract:% = contract_name; "Contract already declared.");
         }
         TransactionResult::Hash(hash) => {
-            debug!("Contract {} declared.", contract_name);
-            trace!("  Tx hash  : {hash:?}");
+            debug!(contract:% = contract_name; "Contract declared.");
+            trace!(tx_hash:? = hash; "Tx hash");
         }
         TransactionResult::HashReceipt(hash, receipt) => {
-            debug!("Contract {} declared.", contract_name);
-            trace!("  Tx hash  : {hash:?}");
-            trace!("  Declared on block  : {}", receipt.block.block_number());
+            debug!(contract:% = contract_name; "Contract declared.");
+            trace!(tx_hash:? = hash, block = receipt.block.block_number(); "Declared on block");
         }
     }
     Ok((class.class_hash, tx_result))
@@ -143,16 +141,15 @@ pub async fn deploy_contract(
         Ok((contract_address, transaction_result)) => {
             match &transaction_result {
                 TransactionResult::Noop => {
-                    debug!("Contract {} already deployed.", contract_name);
+                    debug!(contract:% = contract_name; "Contract already deployed.");
                 }
                 TransactionResult::Hash(hash) => {
-                    debug!("Contract {} deployed.", contract_name);
-                    trace!("  Tx hash  : {hash:?}");
+                    debug!(contract:% = contract_name; "Contract deployed.");
+                    trace!(tx_hash:? = hash; "Tx hash");
                 }
                 TransactionResult::HashReceipt(hash, receipt) => {
-                    debug!("Contract {} deployed.", contract_name);
-                    trace!("  Tx hash  : {hash:?}");
-                    trace!("  At block  : {}", receipt.block.block_number());
+                    debug!(contract:% = contract_name; "Contract deployed.");
+                    trace!(tx_hash:? = hash, block = receipt.block.block_number(); "At block");
                 }
             }
             Ok((contract_address, transaction_result))
@@ -161,8 +158,8 @@ pub async fn deploy_contract(
             let address = try_extract_already_deployed_address(&e)?;
             if let Some(address) = address {
                 warn!(
-                    "{} already deployed at address: {:?}",
-                    contract_name, address
+                    contract:% = contract_name, address:? = address;
+                    "Contract already deployed at address."
                 );
                 // Match the "already declared" semantics: represent an
                 // idempotent no-op with TransactionResult::Noop so the


### PR DESCRIPTION
## Summary

Two things on the same PR now:

1. **stdout is the primary result channel.** Text mode prints a clean hex string (class hash or contract address) to stdout. JSON mode (`--output json`) prints one structured JSON object per invocation. Either way, stdout is parseable without regex.
2. **Human logs stay on stderr, at the right level.** Result-bearing `info!` calls (e.g. `"Core contract address: {:?}"`) that used to be the only way to recover the result from stderr are removed. Existing `info!` progress notes are demoted to `debug!` (status) or `trace!` (tx hash, block number) so `RUST_LOG=warn` or default settings won't drown the user in chatter.

Plus the original change: add `--output {text,json}` and refactor `utils::{declare_contract*, deploy_contract*}` to return `(Felt, TransactionResult)` so tx hash + block number — previously logged and discarded — are available to callers.

## Why

Downstream tooling (docker-compose init containers, terraform external providers, CI scripts, `tests/saya-tee/` in katana) currently greps `info!` lines to extract deployed addresses. That's fragile — any log format change, ANSI color, or filter setting breaks consumers. Two reasons for the cleanup:

- **`info!` was being used as the result channel.** Results belong on stdout, unconditionally visible. Someone running `saya-ops deploy` specifically wants the address — having it behind a log level gate, behind a timestamp-and-module prefix, and on stderr is backwards.
- **`info!` for progress diagnostics was fine, but way too loud by default** (env_logger formatter + every hop through hyper's pool). Demoting progress to `debug!` / `trace!` keeps it when you want it, suppresses it when you don't.

## Example

Before (what `docker/scripts/deploy-contracts.sh` in katana had to do):

```sh
TEE_OUTPUT=$(saya-ops core-contract declare-and-deploy-tee-registry-mock --salt 0x7ee 2>&1)
TEE_REGISTRY_ADDR=$(echo "$TEE_OUTPUT" | grep -m1 "TEE registry mock address" | grep -oE '0x[0-9a-fA-F]+' | head -1)
# ... more regex for block number, tx hash, etc.
```

After, text mode:

```sh
TEE_REGISTRY_ADDR=$(saya-ops core-contract ... declare-and-deploy-tee-registry-mock --salt 0x7ee)
# TEE_REGISTRY_ADDR=0x276abc62eea3f91a7cb5ee8db9916e60e3ce68402b169acf9d07a9c0f543002
```

After, JSON mode (when you need tx hash / block too):

```sh
$ saya-ops core-contract --output json ... declare-and-deploy-tee-registry-mock --salt 0x7ee
{"command":"declare-and-deploy-tee-registry-mock","class_hash":"0x663d...","contract_address":"0x276a...","salt":"0x7ee","tx_hash":"0x266e...","deployed_block":8}
```

## Text mode stdout output per subcommand

| Subcommand | stdout output |
|---|---|
| `declare` | `<class_hash>` |
| `deploy` | `<contract_address>` |
| `declare-and-deploy-fact-registry-mock` | `<contract_address>` |
| `declare-and-deploy-tee-registry-mock` | `<contract_address>` |
| `setup-program` | (nothing; action-only, success = exit 0) |

## JSON schema

`#[serde(tag = "command", rename_all = "kebab-case")]`. One object per invocation:

- `declare` → `{class_hash, tx_hash, declared_block}`
- `deploy` → `{class_hash, contract_address, salt, tx_hash, deployed_block}`
- `declare-and-deploy-fact-registry-mock` → same shape as `deploy`
- `declare-and-deploy-tee-registry-mock` → same shape as `deploy`
- `setup-program` → `{core_contract_address, snos_config_hash, fact_registry_address, set_program_info_tx, set_program_info_block, set_fact_registry_tx, set_fact_registry_block}`

Felts render as `0x`-prefixed lowercase hex strings. `tx_hash` / `*_block` fields are `null` for idempotent no-ops (already-declared / already-deployed cases).

## Log level map (stderr)

| Old | New | What |
|---|---|---|
| `info!("X address: {:?}")` | removed | Was the result. Now on stdout. |
| `info!("Contract X deployed.")` | `debug!` | Progress status. |
| `info!("Contract X already declared.")` | `debug!` | Progress status. |
| `info!("Tx hash   : {hash:?}")` | `trace!` | Tx-level detail. |
| `info!("At block  : {block}")` | `trace!` | Tx-level detail. |
| `warn!("already deployed at address")` | `warn!` | Unchanged — legitimate warning. |
| `info!("Starknet OS config hash: ...")` | `debug!` | Intermediate, not a result. |
| `info!("Set program info transaction submitted: ...")` | `debug!` | Progress. |
| `info!("Fact registry set transaction submitted: ...")` | `debug!` | Progress. |

## Behavior change note

**Text mode stdout behavior changed.** Scripts that were capturing `$(saya-ops ...)` expecting empty stdout now get the result hex. Scripts parsing stderr still see the progress info (the logs are preserved, just at `debug!`). If you relied on `info!` being the default level for those lines, add `RUST_LOG=saya_ops=debug` to your environment.

## Test plan

- [x] `cargo check -p saya-ops` clean, `cargo build -p saya-ops` clean
- [x] `saya-ops core-contract --help` shows `--output`
- [x] Tested end-to-end against a local `katana --dev`:
  - Default text mode: stdout = one hex address, stderr = empty
  - `RUST_LOG=debug`: stdout unchanged, stderr shows "Contract X deployed.", tx hashes, etc.
  - `--output json`: stdout = one JSON object, stderr = same as above
  - `declare-and-deploy-tee-registry-mock --salt 0xbee1` → `0x60eedae6...` on stdout, composes with `$( )`
- [x] `println!` + stderr separation verified by redirecting stdout and stderr to different files
- [ ] `tests/saya-tee/` in dojoengine/katana — the existing regex scrape of `info!` output now has to read `debug!` events, so may need `RUST_LOG=saya_ops=debug` in that test's env. Alternative: switch the test to parse stdout (text or JSON). I'll chase that in katana once this lands.

## Follow-ups (not in this PR)

- Equivalent treatment for `saya-tee` (daemon, structured tracing events rather than one-shot result).
- Versioned JSON schema file in the saya repo so downstream can codegen types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)