### PR TITLE
refactor(ops): label text-mode stdout output for readability

### DIFF
--- a/bin/ops/src/core_contract/cli.rs
+++ b/bin/ops/src/core_contract/cli.rs
@@ -382,31 +382,41 @@ impl CoreContract {
             }
         };
 
-        // stdout is reserved for the primary command result. Human-readable
-        // progress/diagnostic logs stay on stderr via env_logger (`debug!`
-        // and `trace!`), so the two streams are independently pipeable.
+        // Stdout carries the primary command result. Text mode prints
+        // human-readable `Label: 0x...` lines so a user running the command
+        // interactively can tell at a glance what each hex value is. Scripts
+        // that need to parse reliably should use `--output json`.
         //
-        // `--output json`  → one JSON object per invocation.
-        // `--output text`  → a single hex string (class hash or contract
-        //                    address), or nothing at all for action-only
-        //                    subcommands like `setup-program`.
+        // Diagnostic/progress logs live on stderr via `debug!` + `trace!`.
         match self.output {
             OutputFormat::Json => {
                 println!("{}", serde_json::to_string(&result)?);
             }
             OutputFormat::Text => match &result {
-                CoreContractResult::Declare { class_hash, .. } => println!("{}", class_hash),
+                CoreContractResult::Declare { class_hash, .. } => {
+                    println!("Core contract class hash: {}", class_hash);
+                }
                 CoreContractResult::Deploy {
                     contract_address, ..
-                } => println!("{}", contract_address),
+                } => {
+                    println!("Core contract address: {}", contract_address);
+                }
                 CoreContractResult::DeclareAndDeployFactRegistryMock {
+                    class_hash,
                     contract_address,
                     ..
-                } => println!("{}", contract_address),
+                } => {
+                    println!("Fact registry mock class hash: {}", class_hash);
+                    println!("Fact registry mock address: {}", contract_address);
+                }
                 CoreContractResult::DeclareAndDeployTeeRegistryMock {
+                    class_hash,
                     contract_address,
                     ..
-                } => println!("{}", contract_address),
+                } => {
+                    println!("TEE registry mock class hash: {}", class_hash);
+                    println!("TEE registry mock address: {}", contract_address);
+                }
                 CoreContractResult::SetupProgram { .. } => {
                     // Action, not query: success is implied by a zero exit
                     // code. Users who want the tx hashes can request them


### PR DESCRIPTION
## Summary

Text-mode stdout used to be a bare hex string. Now it's `Label: 0x...`.

```
# Before
$ saya-ops core-contract ... deploy --salt 0x5
0x3a8c54fd...

# After
$ saya-ops core-contract ... deploy --salt 0x5
Core contract address: 0x3a8c54fd...
```

```
# declare-and-deploy-* prints both hashes with labels now
$ saya-ops core-contract ... declare-and-deploy-tee-registry-mock --salt 0x7ee
TEE registry mock class hash: 0x663dafa1...
TEE registry mock address: 0x37189b18...
```

Script consumers should use `--output json` — stable keys, no prose to parse. Text mode is for humans at a terminal.

## Subcommand → text output map

| Subcommand | Text mode stdout |
|---|---|
| `declare` | `Core contract class hash: 0x...` |
| `deploy` | `Core contract address: 0x...` |
| `declare-and-deploy-fact-registry-mock` | `Fact registry mock class hash: 0x...` + `Fact registry mock address: 0x...` |
| `declare-and-deploy-tee-registry-mock` | `TEE registry mock class hash: 0x...` + `TEE registry mock address: 0x...` |
| `setup-program` | (nothing; action, not query) |

JSON-mode output is unchanged.

## Breaking change

Anyone doing `ADDR=\$(saya-ops ... deploy)` on text output gets the labeled string now, not bare hex. The fix for those consumers is to switch to `--output json`:

```sh
ADDR=\$(saya-ops ... --output json deploy --salt 0x5 | jq -r .contract_address)
```
