### PR TITLE
fix(ci): install rust target for 1.91 toolchain in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,7 @@ jobs:
         run: |
           rustup target add --toolchain 1.87 ${{ matrix.job.target }}
           rustup target add --toolchain 1.89 ${{ matrix.job.target }}
+          rustup target add --toolchain 1.91 ${{ matrix.job.target }}
 
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Summary

The release workflow's \`Install target\` step pre-installs the cross-compile target for toolchains 1.87 and 1.89 only. Since \`bin/ops/rust-toolchain.toml\` pins channel 1.91, the binary build fails on all four target matrix jobs:

\`\`\`
error[E0463]: can't find crate for \`core\`
  note: the \`x86_64-apple-darwin\` target may not be installed
\`\`\`

(cfg-if just happens to be the first thing cargo compiles, so that's where it surfaces.)

Broke the v0.3.2 release run: https://github.com/dojoengine/saya/actions/runs/24799533228

## Fix

Add one line to pre-install the target for 1.91 too.

## Test plan

- [ ] Re-run release for v0.3.2 once this merges — all four target matrix jobs should reach \`Archive binaries\`
- [ ] Longer-term: consider driving target installs from the actual \`rust-toolchain.toml\` pins rather than hardcoding channels, so future toolchain bumps don't silently break the release. Not doing that here — minimal-diff fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)