### PR TITLE
chore(ops): pin rust toolchain to 1.89 to match the rest of saya

### DIFF
--- a/bin/ops/rust-toolchain.toml
+++ b/bin/ops/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.91"
+channel = "1.89"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
## Summary

\`bin/ops\` was the only crate on Rust 1.91; everything else is 1.87 or 1.89. Drops \`bin/ops/rust-toolchain.toml\` from \`channel = \"1.91\"\` → \`\"1.89\"\`. Compiles clean at 1.89.

## Why

The release workflow pre-installs cross-compile targets for toolchains 1.87 and 1.89. 1.91 was never added. When the release build ran \`cargo build --target <target>\` inside \`bin/ops\`, rustup auto-downloaded 1.91 but without the target stdlib pre-installed — producing \`error[E0463]: can't find crate for core\` on every matrix job and blocking v0.3.2.

Two ways to fix:
- Add 1.91 to the workflow's \`Install target\` step (proposed in #68).
- Drop \`bin/ops\` to 1.89 to match the rest of the repo. ← This PR.

The second is cheaper: one fewer pinned toolchain to worry about, no new CI surface, and the 1.91 pin was never justified by any MSRV need (all deps build clean at 1.89).

## Test plan

- [x] \`cargo build --release --all-features -p saya-ops\` clean on 1.89 locally (1m 46s cold build)
- [ ] v0.3.2 release retriggered after merge — all four target matrix jobs reach \`Archive binaries\`

## Relation to #68

Supersedes #68. If this merges, #68 can close without landing — the workflow stays minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)