### PR TITLE
refactor(logging): migrate from `log`/`env_logger` to `tracing-subscriber`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4969,7 +4969,6 @@ dependencies = [
  "ciborium",
  "futures-util",
  "hex",
- "log",
  "num-traits",
  "piltover",
  "serde",
@@ -4983,6 +4982,7 @@ dependencies = [
  "thiserror 2.0.16",
  "tokio",
  "tokio-util",
+ "tracing",
  "url",
 ]
 
@@ -4996,6 +4996,17 @@ dependencies = [
  "starknet-types-core",
  "tokio",
  "url",
+]
+
+[[package]]
+name = "saya-tracing"
+version = "0.3.2"
+dependencies = [
+ "chrono",
+ "thiserror 2.0.16",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 resolver = "2"
 members = [
     "saya/core",
-    "tests/e2e", 
+    "saya/tracing",
+    "tests/e2e",
 ]
 
 [workspace.package]
@@ -17,6 +18,7 @@ repository = "https://github.com/dojoengine/saya"
 [workspace.dependencies]
 # saya
 saya-core = { path = "saya/core" }
+saya-tracing = { path = "saya/tracing" }
 starknet_api = { git = "https://github.com/karnotxyz/sequencer", rev = "e04617e0581d5ec93a035ec0e15419b4c201b629", features = [
   "testing",
 ] }
@@ -27,13 +29,12 @@ bigdecimal = { version = "0.3.1", default-features = false }
 cairo-vm = "=2.5.0"
 celestia-rpc = { version = "0.16.2", default-features = false }
 celestia-types = { version = "0.20.0", default-features = false }
+chrono = { version = "0.4.39", default-features = false, features = ["clock"] }
 ciborium = { version = "0.2.2", default-features = false }
 clap = { version = "4.5.23", default-features = false, features = ["derive", "env", "std"] }
-env_logger = {version = "0.11.6",features = ["unstable-kv"]}
 futures-util = { version ="0.3.31", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 integrity = { git = "https://github.com/chudkowsky/integrity-rs.git", rev = "9729be1", default-features = false, features = ["recursive_with_poseidon", "keccak_160_lsb", "stone6"] }
-log = {version = "0.4.22",features = ["kv"]}
 num-traits = { version = "0.2.19", default-features = false }
 reqwest = { version = "0.12.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }
 serde = { version = "1.0.217", default-features = false, features = ["derive"] }
@@ -53,6 +54,9 @@ swiftness_stark = { git = "https://github.com/chudkowsky/swiftness", rev = "e07d
 thiserror = "2.0.12"
 tokio = { version = "1.42.0", default-features = false }
 tokio-util = { version = "0.7.13", default-features = false }
+tracing = { version = "0.1.40", default-features = false, features = ["std", "attributes"] }
+tracing-log = { version = "0.2.0", default-features = false }
+tracing-subscriber = { version = "0.3.18", default-features = false, features = ["fmt", "env-filter", "registry", "ansi", "tracing-log"] }
 url = { version = "2.5.4", default-features = false }
 zip = { version = "2.2.2", default-features = false, features = ["deflate"] }
 sqlx = { version = "0.8.2", features = [ "chrono", "macros", "regexp", "runtime-async-std", "runtime-tokio", "sqlite", "uuid" ] }

--- a/bin/ops/Cargo.lock
+++ b/bin/ops/Cargo.lock
@@ -57,27 +57,12 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse 0.2.7",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
- "anstyle-parse 1.0.0",
+ "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -90,15 +75,6 @@ name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
 
 [[package]]
 name = "anstyle-parse"
@@ -1345,7 +1321,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream 1.0.0",
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim 0.11.1",
@@ -1949,29 +1925,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "env_filter"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
-dependencies = [
- "anstream 0.6.21",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
 ]
 
 [[package]]
@@ -2931,30 +2884,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jiff"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "jni"
@@ -4481,15 +4410,26 @@ dependencies = [
  "celestia-types",
  "clap",
  "dojo-utils",
- "env_logger",
  "hex",
- "log",
+ "saya-tracing",
  "serde",
  "serde_json",
  "starknet",
  "starknet_api",
  "tokio",
+ "tracing",
  "url",
+]
+
+[[package]]
+name = "saya-tracing"
+version = "0.3.2"
+dependencies = [
+ "chrono",
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/bin/ops/Cargo.toml
+++ b/bin/ops/Cargo.toml
@@ -29,9 +29,9 @@ clap = { version = "4.5.23", default-features = false, features = [
     "std",
 ] }
 dojo-utils = { git = "https://github.com/dojoengine/dojo", rev = "9b64ea8dc9bc6be8992dba87c104378dbf09b565" }
-env_logger = { version = "0.11.6", features = ["unstable-kv"] }
-log = { version = "0.4.22", features = ["kv"] }
+saya-tracing = { path = "../../saya/tracing" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+tracing = { version = "0.1.40", default-features = false, features = ["std", "attributes"] }
 serde_json = { version = "1.0.134", default-features = false }
 starknet = { git = "https://github.com/dojoengine/starknet-rs", branch = "feat/types-rs-100-blake2s" }
 starknet_api = { git = "https://github.com/karnotxyz/sequencer", rev = "e04617e0581d5ec93a035ec0e15419b4c201b629" }

--- a/bin/ops/src/celestia.rs
+++ b/bin/ops/src/celestia.rs
@@ -3,7 +3,7 @@ use base64::{engine::general_purpose::STANDARD, Engine as _};
 use celestia_rpc::{BlobClient, Client};
 use celestia_types::{blob::Commitment, nmt::Namespace};
 use clap::{Args, Parser, Subcommand};
-use log::info;
+use tracing::info;
 
 #[derive(Debug, Parser)]
 pub struct Celestia {

--- a/bin/ops/src/core_contract/cli.rs
+++ b/bin/ops/src/core_contract/cli.rs
@@ -13,13 +13,13 @@ use crate::core_contract::utils::{
 use anyhow::Result;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use dojo_utils::TransactionResult;
-use log::debug;
 use serde::Serialize;
 use starknet::core::types::Felt;
 use starknet::core::utils::cairo_short_string_to_felt;
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::{JsonRpcClient, Provider};
 use starknet::signers::{LocalWallet, SigningKey};
+use tracing::debug;
 use url::Url;
 
 /// Output format for the final result of a subcommand.
@@ -282,19 +282,18 @@ impl CoreContract {
                 }
             }
             CoreContractCmd::DeclareAndDeployFactRegistryMock(deploy_fact_registry_args) => {
-                let (class_hash, _declare_tx) = if let Some(path) =
-                    deploy_fact_registry_args.fact_registry_path
-                {
-                    declare_contract(account.clone(), "Fact registry mock", Path::new(&path))
+                let (class_hash, _declare_tx) =
+                    if let Some(path) = deploy_fact_registry_args.fact_registry_path {
+                        declare_contract(account.clone(), "Fact registry mock", Path::new(&path))
+                            .await?
+                    } else {
+                        declare_contract_from_bytes(
+                            account.clone(),
+                            "Fact registry mock",
+                            FACT_REGISTRY_MOCK_BYTES,
+                        )
                         .await?
-                } else {
-                    declare_contract_from_bytes(
-                        account.clone(),
-                        "Fact registry mock",
-                        FACT_REGISTRY_MOCK_BYTES,
-                    )
-                    .await?
-                };
+                    };
 
                 let (fact_registry_address, deploy_tx) = deploy_contract(
                     account.clone(),
@@ -315,18 +314,18 @@ impl CoreContract {
                 }
             }
             CoreContractCmd::DeclareAndDeployTeeRegistryMock(deploy_tee_registry_args) => {
-                let (class_hash, _declare_tx) =
-                    if let Some(path) = deploy_tee_registry_args.tee_registry_path {
-                        declare_contract(account.clone(), "TEE registry mock", Path::new(&path))
-                            .await?
-                    } else {
-                        declare_contract_from_bytes(
-                            account.clone(),
-                            "TEE registry mock",
-                            TEE_REGISTRY_MOCK_BYTES,
-                        )
-                        .await?
-                    };
+                let (class_hash, _declare_tx) = if let Some(path) =
+                    deploy_tee_registry_args.tee_registry_path
+                {
+                    declare_contract(account.clone(), "TEE registry mock", Path::new(&path)).await?
+                } else {
+                    declare_contract_from_bytes(
+                        account.clone(),
+                        "TEE registry mock",
+                        TEE_REGISTRY_MOCK_BYTES,
+                    )
+                    .await?
+                };
 
                 let (tee_registry_address, deploy_tx) = deploy_contract(
                     account.clone(),
@@ -351,7 +350,7 @@ impl CoreContract {
 
                 let snos_config_hash =
                     compute_starknet_os_config_hash(chain_id, setup_program_args.fee_token_address);
-                debug!(snos_config_hash:? = snos_config_hash; "Computed Starknet OS config hash.");
+                debug!(snos_config_hash = ?snos_config_hash, "Computed Starknet OS config hash.");
                 let set_program_tx = set_program_info(
                     account.clone(),
                     setup_program_args.core_contract_address,
@@ -360,14 +359,14 @@ impl CoreContract {
                 .await?;
                 let fact_registry =
                     self.get_fact_registry_address(setup_program_args.fact_registry_address);
-                debug!(tx:? = set_program_tx; "set_program_info transaction submitted.");
+                debug!(tx = ?set_program_tx, "set_program_info transaction submitted.");
                 let set_fact_tx = set_fact_registry(
                     account.clone(),
                     setup_program_args.core_contract_address,
                     fact_registry,
                 )
                 .await?;
-                debug!(tx:? = set_fact_tx; "set_fact_registry transaction submitted.");
+                debug!(tx = ?set_fact_tx, "set_fact_registry transaction submitted.");
                 let (spi_tx_hash, spi_block) = tx_outcome(&set_program_tx);
                 let (sfr_tx_hash, sfr_block) = tx_outcome(&set_fact_tx);
                 CoreContractResult::SetupProgram {

--- a/bin/ops/src/core_contract/utils.rs
+++ b/bin/ops/src/core_contract/utils.rs
@@ -8,7 +8,6 @@ use anyhow::Result;
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet_classes::contract_class::ContractClass;
 use dojo_utils::{Declarer, Deployer, Invoker, LabeledClass, TransactionResult, TxnConfig};
-use log::{debug, trace, warn};
 use starknet::accounts::{Account, SingleOwnerAccount};
 use starknet::core::crypto::compute_hash_on_elements;
 use starknet::core::types::{contract::SierraClass, Call, Felt, FlattenedSierraClass};
@@ -18,6 +17,7 @@ use starknet::providers::JsonRpcClient;
 use starknet::signers::LocalWallet;
 use starknet_api::contract_class::compiled_class_hash::{HashVersion, HashableCompiledClass};
 use std::{fs, path::Path};
+use tracing::{debug, trace, warn};
 
 pub fn compute_starknet_os_config_hash(chain_id: Felt, fee_token: Felt) -> Felt {
     const STARKNET_OS_CONFIG_VERSION: Felt = short_string!("StarknetOsConfig3");
@@ -45,15 +45,15 @@ pub async fn declare_contract(
 
     match &tx_result {
         TransactionResult::Noop => {
-            debug!(contract:% = contract_name; "Contract already declared.");
+            debug!(contract = %contract_name, "Contract already declared.");
         }
         TransactionResult::Hash(hash) => {
-            debug!(contract:% = contract_name; "Contract declared.");
-            trace!(tx_hash:? = hash; "Tx hash");
+            debug!(contract = %contract_name, "Contract declared.");
+            trace!(tx_hash = ?hash, "Tx hash");
         }
         TransactionResult::HashReceipt(hash, receipt) => {
-            debug!(contract:% = contract_name; "Contract declared.");
-            trace!(tx_hash:? = hash, block = receipt.block.block_number(); "Declared on block");
+            debug!(contract = %contract_name, "Contract declared.");
+            trace!(tx_hash = ?hash, block = receipt.block.block_number(), "Declared on block");
         }
     }
     Ok((class.class_hash, tx_result))
@@ -79,15 +79,15 @@ pub async fn declare_contract_from_bytes(
 
     match &tx_result {
         TransactionResult::Noop => {
-            debug!(contract:% = contract_name; "Contract already declared.");
+            debug!(contract = %contract_name, "Contract already declared.");
         }
         TransactionResult::Hash(hash) => {
-            debug!(contract:% = contract_name; "Contract declared.");
-            trace!(tx_hash:? = hash; "Tx hash");
+            debug!(contract = %contract_name, "Contract declared.");
+            trace!(tx_hash = ?hash, "Tx hash");
         }
         TransactionResult::HashReceipt(hash, receipt) => {
-            debug!(contract:% = contract_name; "Contract declared.");
-            trace!(tx_hash:? = hash, block = receipt.block.block_number(); "Declared on block");
+            debug!(contract = %contract_name, "Contract declared.");
+            trace!(tx_hash = ?hash, block = receipt.block.block_number(), "Declared on block");
         }
     }
     Ok((class.class_hash, tx_result))
@@ -141,15 +141,15 @@ pub async fn deploy_contract(
         Ok((contract_address, transaction_result)) => {
             match &transaction_result {
                 TransactionResult::Noop => {
-                    debug!(contract:% = contract_name; "Contract already deployed.");
+                    debug!(contract = %contract_name, "Contract already deployed.");
                 }
                 TransactionResult::Hash(hash) => {
-                    debug!(contract:% = contract_name; "Contract deployed.");
-                    trace!(tx_hash:? = hash; "Tx hash");
+                    debug!(contract = %contract_name, "Contract deployed.");
+                    trace!(tx_hash = ?hash, "Tx hash");
                 }
                 TransactionResult::HashReceipt(hash, receipt) => {
-                    debug!(contract:% = contract_name; "Contract deployed.");
-                    trace!(tx_hash:? = hash, block = receipt.block.block_number(); "At block");
+                    debug!(contract = %contract_name, "Contract deployed.");
+                    trace!(tx_hash = ?hash, block = receipt.block.block_number(), "At block");
                 }
             }
             Ok((contract_address, transaction_result))
@@ -158,7 +158,8 @@ pub async fn deploy_contract(
             let address = try_extract_already_deployed_address(&e)?;
             if let Some(address) = address {
                 warn!(
-                    contract:% = contract_name, address:? = address;
+                    contract = %contract_name,
+                    address = ?address,
                     "Contract already deployed at address."
                 );
                 // Match the "already declared" semantics: represent an

--- a/bin/ops/src/main.rs
+++ b/bin/ops/src/main.rs
@@ -32,13 +32,7 @@ enum Subcommands {
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    if std::env::var("RUST_LOG").is_err() {
-        std::env::set_var(
-            "RUST_LOG",
-            "info,saya=trace,saya_core=trace,rpc_client=info",
-        );
-    }
-    env_logger::init();
+    saya_tracing::init("info,saya=trace,saya_core=trace,rpc_client=info")?;
     match cli.command {
         Subcommands::CoreContract(cmd) => cmd.run().await,
         Subcommands::Celestia(cmd) => cmd.run().await,

--- a/bin/persistent-tee/Cargo.lock
+++ b/bin/persistent-tee/Cargo.lock
@@ -4340,29 +4340,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5867,30 +5844,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jiff"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "jni"
@@ -8918,7 +8871,6 @@ dependencies = [
  "ciborium",
  "futures-util",
  "hex",
- "log",
  "num-traits",
  "piltover",
  "serde",
@@ -8931,6 +8883,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "tracing",
  "url",
 ]
 
@@ -8945,18 +8898,29 @@ dependencies = [
  "anyhow",
  "cainome",
  "clap",
- "env_logger",
  "katana_tee_client",
- "log",
  "piltover",
  "saya-core",
+ "saya-tracing",
  "sha3",
  "starknet",
  "starknet-types-core 0.2.4",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "url",
  "x509-verifier-rust-crypto",
+]
+
+[[package]]
+name = "saya-tracing"
+version = "0.3.2"
+dependencies = [
+ "chrono",
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/bin/persistent-tee/Cargo.toml
+++ b/bin/persistent-tee/Cargo.toml
@@ -31,12 +31,12 @@ sha3 = "0.10"
 
 anyhow = "1"
 clap = { version = "4", default-features = false, features = ["derive", "env", "std"] }
-env_logger = { version = "0.11", features = ["unstable-kv"] }
-log = { version = "0.4", features = ["kv"] }
+saya-tracing = { path = "../../saya/tracing" }
 starknet = "0.17.0"
 starknet-types-core = { version = "0.2.1", default-features = false }
 thiserror = "2"
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "macros", "signal", "time"] }
+tracing = { version = "0.1.40", default-features = false, features = ["std", "attributes"] }
 url = "2"
 
 [patch.crates-io]

--- a/bin/persistent-tee/src/attestor.rs
+++ b/bin/persistent-tee/src/attestor.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 
 use anyhow::Result;
 use katana_tee_client::KatanaRpcClient;
-use log::{debug, info};
 use tokio::sync::mpsc::{Receiver, Sender};
+use tracing::{debug, error, info};
 use url::Url;
 
 #[allow(unused_imports)]
@@ -104,16 +104,16 @@ impl TeeAttestor {
                 },
             };
             info!(
-                first_block = blocks.first().map(|b| b.number),
-                last_block = blocks.last().map(|b| b.number),
-                count = blocks.len();
+                first_block = ?blocks.first().map(|b| b.number),
+                last_block = ?blocks.last().map(|b| b.number),
+                count = blocks.len(),
                 "Fetching TEE attestation for block batch"
             );
 
             let attestation = match self.fetch_attestation(blocks).await {
                 Ok(a) => a,
                 Err(e) => {
-                    log::error!("Failed to fetch TEE attestation: {}", e);
+                    error!("Failed to fetch TEE attestation: {}", e);
                     continue;
                 }
             };

--- a/bin/persistent-tee/src/main.rs
+++ b/bin/persistent-tee/src/main.rs
@@ -35,10 +35,7 @@ enum Subcommands {
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    if std::env::var("RUST_LOG").is_err() {
-        std::env::set_var("RUST_LOG", "info,persistent_tee=trace,saya_core=trace");
-    }
-    env_logger::init();
+    saya_tracing::init("info,persistent_tee=trace,saya_core=trace")?;
 
     match cli.command {
         Subcommands::Tee(cmd) => cmd.run().await,

--- a/bin/persistent-tee/src/prover.rs
+++ b/bin/persistent-tee/src/prover.rs
@@ -14,7 +14,6 @@ use crate::prover_impl::TeeAttestation as TeeAttestationProver;
 use anyhow::Result;
 use katana_tee_client::ProverConfig;
 use katana_tee_client::TeeQuoteResponse;
-use log::{debug, info};
 use saya_core::{
     prover::{HasBlockNumber, PipelineStage, PipelineStageBuilder, TeeProof},
     service::{Daemon, FinishHandle, ShutdownHandle},
@@ -22,6 +21,7 @@ use saya_core::{
 };
 use starknet_types_core::felt::Felt;
 use tokio::sync::mpsc::{Receiver, Sender};
+use tracing::{debug, error, info};
 
 /// Submits a [`TeeAttestation`] to the TEE proving service and emits the resulting [`TeeProof`].
 #[derive(Debug)]
@@ -121,12 +121,15 @@ impl TeeProver {
                 },
             };
 
-            debug!(block_number = attestation.block_number(); "Submitting TEE attestation to prover");
+            debug!(
+                block_number = attestation.block_number(),
+                "Submitting TEE attestation to prover"
+            );
 
             let proof = match self.prove(attestation).await {
                 Ok(p) => p,
                 Err(e) => {
-                    log::error!("TEE proof generation failed: {}", e);
+                    error!("TEE proof generation failed: {}", e);
                     continue;
                 }
             };
@@ -150,7 +153,10 @@ impl TeeProver {
         let block_hash = Felt::from_hex(&attestation.block_hash)?;
 
         let proof_raw = if self.mock_prove {
-            info!(block_number; "TEE mock proving (no SP1, no KDS, no AMD verification)");
+            info!(
+                block_number,
+                "TEE mock proving (no SP1, no KDS, no AMD verification)"
+            );
             let commitment = mock_proof::compute_appchain_commitment(
                 prev_state_root,
                 state_root,
@@ -163,7 +169,7 @@ impl TeeProver {
             let felts = mock_proof::serialize_mock_journal(commitment);
             mock_proof::felts_to_bytes(&felts)
         } else {
-            info!(block_number; "TEE proving started for block batch");
+            info!(block_number, "TEE proving started for block batch");
             let response = TeeQuoteResponse {
                 quote: attestation.quote.clone(),
                 prev_state_root: attestation.prev_state_root.clone(),
@@ -187,7 +193,11 @@ impl TeeProver {
                 .generate_proof(&self.provider_url, self.registry_address, config)
                 .await?;
             let proof_raw = proof.encode_json()?;
-            info!(block_number; "TEE proving completed, proof size: {} bytes", proof_raw.len());
+            info!(
+                block_number,
+                "TEE proving completed, proof size: {} bytes",
+                proof_raw.len()
+            );
             proof_raw
         };
 

--- a/bin/persistent-tee/src/prover_impl.rs
+++ b/bin/persistent-tee/src/prover_impl.rs
@@ -9,9 +9,9 @@
 
 use anyhow::Result;
 use katana_tee_client::{OnchainProof, ProverConfig, StarknetRegistryClient};
-use log::info;
 use starknet_types_core::felt::Felt;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tracing::{debug, info};
 
 /// Structured error type for TEE attestation operations.
 #[derive(Debug, thiserror::Error)]
@@ -157,7 +157,7 @@ impl TeeAttestation {
                             None,
                             None,
                         );
-                    log::debug!("{:?} {}", input, "SP1 Groth16 prover input");
+                    debug!("{:?} {}", input, "SP1 Groth16 prover input");
                     let raw_proof = prover
                         .verifier
                         .gen_proof(&input, RawProofType::Groth16, None)

--- a/bin/persistent-tee/src/settlement.rs
+++ b/bin/persistent-tee/src/settlement.rs
@@ -5,7 +5,6 @@ use std::{sync::Arc, time::Duration};
 use anyhow::Result;
 use cainome::cairo_serde::{CairoSerde, ContractAddress};
 use katana_tee_client::{OnchainProof, StarknetCalldata};
-use log::debug;
 use piltover::{MessageToAppchain, MessageToStarknet, PiltoverInput, TEEInput};
 use sha3::{Digest, Keccak256};
 use starknet::{
@@ -16,6 +15,7 @@ use starknet::{
     signers::{LocalWallet, SigningKey},
 };
 use tokio::sync::mpsc::{Receiver, Sender};
+use tracing::{debug, error};
 use url::Url;
 
 use saya_core::{
@@ -263,7 +263,7 @@ impl TeePiltoverSettlementBackend {
             let calldata = match build_tee_calldata(&proof, self.mock_prove) {
                 Ok(c) => c,
                 Err(e) => {
-                    log::error!(
+                    error!(
                         "Failed to build TEE calldata for block {}: {}",
                         proof.block_number.to_hex_string(),
                         e
@@ -283,7 +283,7 @@ impl TeePiltoverSettlementBackend {
             let _fees = match execution.estimate_fee().await {
                 Ok(f) => f,
                 Err(e) => {
-                    log::error!(
+                    error!(
                         "Fee estimation failed for block {}: {}",
                         proof.block_number.to_hex_string(),
                         e
@@ -294,10 +294,9 @@ impl TeePiltoverSettlementBackend {
             let transaction = match execution.send().await {
                 Ok(t) => t,
                 Err(e) => {
-                    log::error!(
+                    error!(
                         "Settlement transaction failed for block {}: {}",
-                        proof.block_number,
-                        e
+                        proof.block_number, e
                     );
                     continue;
                 }
@@ -306,10 +305,9 @@ impl TeePiltoverSettlementBackend {
             match self.watch_tx(transaction.transaction_hash).await {
                 Ok(()) => {}
                 Err(e) => {
-                    log::error!(
+                    error!(
                         "Settlement tx confirmation failed for block {}: {}",
-                        proof.block_number,
-                        e
+                        proof.block_number, e
                     );
                     continue;
                 }

--- a/bin/persistent/Cargo.lock
+++ b/bin/persistent/Cargo.lock
@@ -6146,16 +6146,15 @@ dependencies = [
  "cairo-vm",
  "ciborium",
  "clap",
- "env_logger",
  "futures-util",
  "generate-pie",
  "hex",
  "integrity",
- "log",
  "num-traits",
  "piltover 0.1.0 (git+https://github.com/cartridge-gg/piltover.git?rev=67e65b8928b7ee3c2c188bf36c6b9eddc14addb2)",
  "reqwest 0.12.23",
  "saya-core",
+ "saya-tracing",
  "serde",
  "serde_json",
  "starknet",
@@ -6170,6 +6169,7 @@ dependencies = [
  "swiftness_stark",
  "thiserror 2.0.16",
  "tokio",
+ "tracing",
  "url",
  "zip 2.4.2",
 ]
@@ -6186,7 +6186,6 @@ dependencies = [
  "ciborium",
  "futures-util",
  "hex",
- "log",
  "num-traits",
  "piltover 0.1.0 (git+https://github.com/cartridge-gg/piltover.git?rev=dc86b13de0713c172153c4833fd7b3d14a855351)",
  "serde",
@@ -6200,7 +6199,19 @@ dependencies = [
  "thiserror 2.0.16",
  "tokio",
  "tokio-util",
+ "tracing",
  "url",
+]
+
+[[package]]
+name = "saya-tracing"
+version = "0.3.1"
+dependencies = [
+ "chrono",
+ "thiserror 2.0.16",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/bin/persistent/Cargo.toml
+++ b/bin/persistent/Cargo.toml
@@ -46,9 +46,9 @@ clap = { version = "4.5.23", default-features = false, features = [
     "env",
     "std",
 ] }
-env_logger = { version = "0.11.6", features = ["unstable-kv"] }
-log = { version = "0.4.22", features = ["kv"] }
 saya-core = { path = "../../saya/core", features = ["snos"] }
+saya-tracing = { path = "../../saya/tracing" }
+tracing = { version = "0.1.40", default-features = false, features = ["std", "attributes"] }
 starknet = "0.17.0"
 starknet_api = { git = "https://github.com/karnotxyz/sequencer", rev = "e04617e0581d5ec93a035ec0e15419b4c201b629" }
 starknet-types-core = { version = "0.2.1", default-features = false }

--- a/bin/persistent/src/atlantic/layout_bridge.rs
+++ b/bin/persistent/src/atlantic/layout_bridge.rs
@@ -10,7 +10,6 @@ use crate::{
 };
 use anyhow::Result;
 use cairo_vm::vm::runners::cairo_pie::CairoPie;
-use log::{debug, info, trace, warn};
 use saya_core::{
     block_ingestor::BlockInfo,
     prover::{PipelineStage, PipelineStageBuilder, SnosProof},
@@ -21,6 +20,7 @@ use tokio::sync::{
     mpsc::{Receiver, Sender},
     Mutex,
 };
+use tracing::{debug, error, info, trace, warn};
 /// Prover implementation as a client to the hosted [Atlantic Prover](https://atlanticprover.com/)
 /// service.
 #[derive(Debug)]
@@ -82,7 +82,7 @@ where
                     let proof = swiftness::parse(verifier_proof);
                     if proof.is_ok() {
                         trace!(
-                            block_number = new_snos_proof.block_number;
+                            block_number = new_snos_proof.block_number,
                             "Proof already generated for block"
                         );
                         let block_info = BlockInfo {
@@ -96,14 +96,14 @@ where
                     } else {
                         // TODO: ensure the following match on the `get_query_id` isn't conflicting with this situation.
                         warn!(
-                            block_number = new_snos_proof.block_number;
+                            block_number = new_snos_proof.block_number,
                             "Invalid proof found in db, not using proof from db.",
                         );
                     }
                 }
                 Err(_) => {
                     trace!(
-                        block_number = new_snos_proof.block_number;
+                        block_number = new_snos_proof.block_number,
                         "Proof not found in db for block",
                     );
                 }
@@ -114,7 +114,10 @@ where
                 .await
             {
                 Ok(atlantic_query_id) => {
-                    info!(block_number = new_snos_proof.block_number; "Proof generation already submitted for block");
+                    info!(
+                        block_number = new_snos_proof.block_number,
+                        "Proof generation already submitted for block"
+                    );
                     let query_response = match wait_for_query(
                         client.clone(),
                         atlantic_query_id.clone(),
@@ -126,15 +129,14 @@ where
                             break;
                         }
                         Err(ProverError::BlockFail(e)) => {
-                            log::error!(error:% = e, atlantic_query_id:% = atlantic_query_id; "Proof generation failed");
+                            error!(error = %e, atlantic_query_id = %atlantic_query_id, "Proof generation failed");
                             db.add_failed_block(block_number_u32, e).await.unwrap();
                             continue;
                         }
                         Err(e) => {
-                            log::error!(
+                            error!(
                                 "Unreachable error: {:?} while processing query {}",
-                                e,
-                                atlantic_query_id
+                                e, atlantic_query_id
                             );
                             unreachable!("Unexpected ProverError: {:?}", e);
                         }
@@ -142,7 +144,7 @@ where
                     };
 
                     debug!(
-                        atlantic_query_id:? = atlantic_query_id;
+                        atlantic_query_id = ?atlantic_query_id,
                         "Atlantic layout bridge proof generation finished"
                     );
 
@@ -167,7 +169,7 @@ where
                 }
                 Err(_) => {
                     trace!(
-                        block_number = new_snos_proof.block_number;
+                        block_number = new_snos_proof.block_number,
                         "Proof generation not submitted for block"
                     );
                 }
@@ -216,7 +218,7 @@ where
 
                     info!(
                         block_number = new_snos_proof.block_number,
-                        atlantic_query_id:? = atlantic_query_id;
+                        atlantic_query_id = ?atlantic_query_id,
                         "Atlantic trace generation submitted",
                     );
 
@@ -231,15 +233,14 @@ where
                             break;
                         }
                         Err(ProverError::BlockFail(e)) => {
-                            log::error!("{}", e,);
+                            error!("{}", e);
                             db.add_failed_block(block_number_u32, e).await.unwrap();
                             continue;
                         }
                         Err(e) => {
-                            log::error!(
+                            error!(
                                 "Unreachable error: {:?} while processing query {}",
-                                e,
-                                atlantic_query_id
+                                e, atlantic_query_id
                             );
                             unreachable!("Unexpected ProverError: {:?}", e);
                         }
@@ -286,7 +287,7 @@ where
 
             info!(
                 block_number = new_snos_proof.block_number,
-                atlantic_query_id:? = atlantic_query_id;
+                atlantic_query_id = ?atlantic_query_id,
                 "Atlantic layout bridge proof generation submitted",
             );
 
@@ -300,15 +301,14 @@ where
             {
                 Err(ProverError::Shutdown) => break,
                 Err(ProverError::BlockFail(e)) => {
-                    log::error!(error:% = e, atlantic_query_id:% = atlantic_query_id; "Proof generation failed");
+                    error!(error = %e, atlantic_query_id = %atlantic_query_id, "Proof generation failed");
                     db.add_failed_block(block_number_u32, e).await.unwrap();
                     continue;
                 }
                 Err(e) => {
-                    log::error!(
+                    error!(
                         "Unreachable error: {:?} while processing query {}",
-                        e,
-                        atlantic_query_id
+                        e, atlantic_query_id
                     );
                     unreachable!("Unexpected ProverError: {:?}", e);
                 }
@@ -323,7 +323,7 @@ where
 
             debug!(
                 block_number = new_snos_proof.block_number,
-                atlantic_query_id:? = atlantic_query_id;
+                atlantic_query_id = ?atlantic_query_id,
                 "Atlantic layout bridge proof generation finished",
             );
 

--- a/bin/persistent/src/atlantic/shared.rs
+++ b/bin/persistent/src/atlantic/shared.rs
@@ -4,13 +4,13 @@ use super::{
 };
 use crate::error::ProverError;
 use cairo_vm::vm::runners::cairo_pie::CairoPie;
-use log::info;
 use saya_core::{
     prover::SnosProof,
     service::FinishHandle,
     storage::{PersistantStorage, Step},
 };
 use std::time::Duration;
+use tracing::info;
 
 const PROOF_STATUS_POLL_INTERVAL: Duration = Duration::from_secs(10);
 
@@ -81,8 +81,7 @@ where
         ))
     })?;
 
-    info!(block_number;
-        "SNOS proof successfully retrieved from Atlantic.");
+    info!(block_number, "SNOS proof successfully retrieved from Atlantic.");
 
     Ok(SnosProof {
         block_number: block_number as u64,

--- a/bin/persistent/src/atlantic/snos.rs
+++ b/bin/persistent/src/atlantic/snos.rs
@@ -2,7 +2,6 @@ use std::{io::Write, sync::Arc, time::Duration};
 
 use anyhow::Result;
 use cairo_vm::vm::runners::cairo_pie::CairoPie;
-use log::{debug, info, trace};
 use starknet::core::types::Felt;
 use tokio::{
     sync::{
@@ -11,6 +10,7 @@ use tokio::{
     },
     task,
 };
+use tracing::{debug, error, info, trace};
 use zip::{write::FileOptions, ZipWriter};
 
 use crate::{
@@ -84,7 +84,10 @@ where
                 .await
             {
                 Ok(proof) => {
-                    info!(block_number = new_block.number; "Proof already generated for block");
+                    info!(
+                        block_number = new_block.number,
+                        "Proof already generated for block"
+                    );
                     let raw_proof = String::from_utf8(proof).unwrap();
                     let parsed_proof: P = P::parse(raw_proof).unwrap();
                     let new_proof = SnosProof {
@@ -96,7 +99,7 @@ where
                 }
                 Err(_) => {
                     trace!(
-                        block_number = block_number_u32;
+                        block_number = block_number_u32,
                         "Proof not found in db for block",
                     );
                 }
@@ -116,7 +119,7 @@ where
                 Ok(atlantic_query_id) => {
                     info!(
                         block_number = new_block.number,
-                        atlantic_query_id:% = atlantic_query_id;
+                        atlantic_query_id = %atlantic_query_id,
                         "Atlantic proof generation already submitted for block",
                     );
                     let query_response = match wait_for_query(
@@ -130,15 +133,14 @@ where
                             break;
                         }
                         Err(ProverError::BlockFail(e)) => {
-                            log::error!("{}", e,);
+                            error!("{}", e);
                             db.add_failed_block(block_number_u32, e).await.unwrap();
                             continue;
                         }
                         Err(e) => {
-                            log::error!(
+                            error!(
                                 "Unreachable error: {:?} while processing query {}",
-                                e,
-                                atlantic_query_id
+                                e, atlantic_query_id
                             );
                             unreachable!("Unexpected ProverError: {:?}", e);
                         }
@@ -200,7 +202,7 @@ where
 
             info!(
                 block_number = new_block.number,
-                atlantic_query_id:% = atlantic_query_id;
+                atlantic_query_id = %atlantic_query_id,
                 "Atlantic proof generation submitted for block"
             );
 
@@ -215,15 +217,14 @@ where
                     break;
                 }
                 Err(ProverError::BlockFail(e)) => {
-                    log::error!("{}", e);
+                    error!("{}", e);
                     db.add_failed_block(block_number_u32, e).await.unwrap();
                     continue;
                 }
                 Err(e) => {
-                    log::error!(
+                    error!(
                         "Unreachable error: {:?} while processing query {}",
-                        e,
-                        atlantic_query_id
+                        e, atlantic_query_id
                     );
                     unreachable!("Unexpected ProverError: {:?}", e);
                 }
@@ -279,7 +280,7 @@ where
         let mock_proof = stark_proof_mock(&output);
 
         info!(
-            block_number = new_block.number;
+            block_number = new_block.number,
             "Mock proof generated from PIE",
         );
 
@@ -395,7 +396,7 @@ pub async fn compress_pie(pie: CairoPie) -> std::result::Result<Vec<u8>, std::io
 fn bootloader_snos_output(pie: &CairoPie) -> Vec<Felt> {
     let snos_program_hash =
         compute_program_hash_from_pie(pie).expect("Failed to compute program hash from PIE");
-    debug!(snos_program_hash:% = snos_program_hash; "SNOS program hash from PIE");
+    debug!(snos_program_hash = %snos_program_hash, "SNOS program hash from PIE");
 
     let snos_output = extract_pie_output(pie);
 

--- a/bin/persistent/src/main.rs
+++ b/bin/persistent/src/main.rs
@@ -46,13 +46,10 @@ enum Subcommands {
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    if std::env::var("RUST_LOG").is_err() {
-        std::env::set_var(
-            "RUST_LOG",
-            "info,persistent=trace,saya_core=trace,rpc_client=info,prove_block=info,blockifier=off,generate_pie=off,rpc_client=off,starknet_os=off",
-        );
-    }
-    env_logger::init();
+    saya_tracing::init(
+        "info,persistent=trace,saya_core=trace,rpc_client=info,prove_block=info,blockifier=off,\
+         generate_pie=off,rpc_client=off,starknet_os=off",
+    )?;
     match cli.command {
         Subcommands::Sovereign(cmd) => cmd.run().await,
         Subcommands::Start(cmd) => cmd.run().await,

--- a/bin/persistent/src/mock/layout_bridge.rs
+++ b/bin/persistent/src/mock/layout_bridge.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
 use integrity::Felt;
-use log::{debug, info};
 use swiftness::TransformTo;
 use swiftness_stark::types::StarkProof;
 use tokio::sync::mpsc::{Receiver, Sender};
+use tracing::{debug, info};
 
 use crate::utils::{calculate_output, stark_proof_mock};
 use saya_core::{

--- a/bin/persistent/src/orchestrator/persistent.rs
+++ b/bin/persistent/src/orchestrator/persistent.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use log::{debug, info};
 use tokio::sync::mpsc::Receiver;
+use tracing::{debug, info};
 
 use saya_core::{
     block_ingestor::{BlockInfo, BlockIngestor, BlockIngestorBuilder},
@@ -165,7 +165,7 @@ impl PersistentOrchestratorState {
 
             info!(
                 block_number = new_cursor.block_number,
-                transaction_hash:% = format!("{:#064x}", new_cursor.transaction_hash);
+                transaction_hash = %format!("{:#064x}", new_cursor.transaction_hash),
                 "Chain advanced to new block"
             );
         }

--- a/bin/persistent/src/orchestrator/sovereign.rs
+++ b/bin/persistent/src/orchestrator/sovereign.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
-use log::{debug, info};
 use swiftness_stark::types::StarkProof;
 use tokio::sync::mpsc::Receiver;
+use tracing::{debug, info};
 
 use saya_core::{
     block_ingestor::{BlockInfo, BlockIngestor, BlockIngestorBuilder},
@@ -180,7 +180,7 @@ where
                     da_pointer,
                 })
                 .await;
-            info!(block_number = new_cursor.block_number; "Chain advanced");
+            info!(block_number = new_cursor.block_number, "Chain advanced");
         }
 
         // Request graceful shutdown for all descendant services

--- a/bin/persistent/src/persistent.rs
+++ b/bin/persistent/src/persistent.rs
@@ -122,8 +122,10 @@ impl Start {
         let [snos_worker_count, layout_bridge_workers_count, ingestor_worker_count] =
             workers_distribution;
 
-        log::info!(
-            snos_worker_count,layout_bridge_workers_count,ingestor_worker_count;
+        tracing::info!(
+            snos_worker_count,
+            layout_bridge_workers_count,
+            ingestor_worker_count,
             "workers distribution"
         );
 

--- a/bin/persistent/src/settlement/piltover.rs
+++ b/bin/persistent/src/settlement/piltover.rs
@@ -3,7 +3,6 @@ use crate::utils::{
 };
 use anyhow::Result;
 use integrity::{split_proof, VerifierConfiguration};
-use log::{debug, info};
 use piltover::{DaLayerInfo, PiltoverInput};
 use saya_core::{
     block_ingestor::BlockInfo,
@@ -30,6 +29,7 @@ use std::{
 use swiftness::types::StarkProof;
 use swiftness::TransformTo;
 use tokio::sync::mpsc::{Receiver, Sender};
+use tracing::{debug, info};
 use url::Url;
 
 const POLLING_INTERVAL: Duration = Duration::from_secs(1);
@@ -150,7 +150,7 @@ where
                                 .collect_calls(integrity_address);
                             let integrity_call_chunks = split_calls(integrity_calls);
                             debug!(
-                                integrity_job_id:% = format!("{:#064x}",integrity_job_id);
+                                integrity_job_id = %format!("{:#064x}",integrity_job_id),
                                 "{} transactions to integrity verifier generated",
                                 integrity_call_chunks.len()
                             );
@@ -196,7 +196,7 @@ where
                                 };
 
                                 debug!(
-                                    transaction_hash:% = format!("{:#064x}", tx.transaction_hash);
+                                    transaction_hash = %format!("{:#064x}", tx.transaction_hash),
                                     "[{} / {}] Integrity verification transaction confirmed",
                                     ind + 1,
                                     integrity_call_chunks.len()
@@ -242,7 +242,7 @@ where
                             program_output = output;
 
                             info!(
-                                block_number = new_da.block_number;
+                                block_number = new_da.block_number,
                                 "On-chain fact-registration skipped for block",
                             );
                         }
@@ -250,13 +250,13 @@ where
                 }
                 saya_core::storage::BlockStatus::VerifiedProof => {
                     info!(
-                        block_number = new_da.block_number;
+                        block_number = new_da.block_number,
                         "Block already verified, skipping verification",
                     );
                 }
                 _ => {
                     info!(
-                        block_number = new_da.block_number;
+                        block_number = new_da.block_number,
                         "Block in unexpected state, skipping settlement",
                     );
                     continue;
@@ -270,7 +270,7 @@ where
                     namespace: pointer.namespace,
                 };
                 info!(
-                    block_number = new_da.block_number;
+                    block_number = new_da.block_number,
                     "Submitting DA layer info with height {} and commitment {:#064x}",
                     da_layer_info.height,
                     da_layer_info.commitment
@@ -289,7 +289,7 @@ where
                 }
             } else {
                 info!(
-                    block_number = new_da.block_number;
+                    block_number = new_da.block_number,
                     "No DA layer info provided, submitting without DA",
                 );
                 Call {
@@ -314,7 +314,7 @@ where
             .await
             .unwrap();
             debug!(
-                block_number = new_da.block_number;
+                block_number = new_da.block_number,
                 "Estimated settlement transaction cost for block: {} STRK",
                 fees.overall_fee
             );
@@ -327,7 +327,7 @@ where
                     .unwrap();
             info!(
                 block_number = new_da.block_number,
-                transaction_hash:% = format!("{:#064x}", transaction.transaction_hash);
+                transaction_hash = %format!("{:#064x}", transaction.transaction_hash),
                 "Piltover statement transaction sent",
             );
 
@@ -343,7 +343,7 @@ where
 
             info!(
                 block_number = new_da.block_number,
-                transaction_hash:% = format!("{:#064x}", transaction.transaction_hash);
+                transaction_hash = %format!("{:#064x}", transaction.transaction_hash),
                 "Piltover statement transaction confirmed",
             );
 

--- a/bin/persistent/src/snos_pie_generator.rs
+++ b/bin/persistent/src/snos_pie_generator.rs
@@ -8,7 +8,6 @@ use generate_pie::{
 };
 
 use crate::atlantic::compress_pie;
-use log::{debug, error, info, trace};
 use saya_core::{
     block_ingestor::BlockInfo,
     prover::{PipelineStage, PipelineStageBuilder},
@@ -23,6 +22,7 @@ use tokio::{
     },
     task,
 };
+use tracing::{debug, error, info, trace};
 use url::Url;
 
 const KATANA_DEFAULT_TOKEN_ADDRESS: &str =
@@ -88,23 +88,23 @@ where
             match db.get_pie(block_number_u32, Step::Snos).await {
                 Ok(pie_bytes) => match CairoPie::from_bytes(&pie_bytes) {
                     Ok(_) => {
-                        trace!(block_number; "SNOS PIE already in DB, skipping generation");
+                        trace!(block_number, "SNOS PIE already in DB, skipping generation");
                         let out = BlockInfo {
                             number: block_number,
                             status: BlockStatus::SnosPieGenerated,
                             state_update: block_info.state_update,
                         };
                         if task_tx.send(out).await.is_err() {
-                            error!(block_number; "Failed to forward block after PIE resume");
+                            error!(block_number, "Failed to forward block after PIE resume");
                         }
                         continue;
                     }
                     Err(err) => {
-                        error!(block_number, error:% = err; "Failed to parse existing PIE from DB");
+                        error!(block_number, error = %err, "Failed to parse existing PIE from DB");
                     }
                 },
                 Err(err) => {
-                    trace!(block_number, error:% = err; "SNOS PIE not found in DB, generating");
+                    trace!(block_number, error = %err, "SNOS PIE not found in DB, generating");
                 }
             }
 
@@ -134,7 +134,7 @@ where
                 .await
                 .unwrap();
 
-            info!(block_number; "SNOS PIE generated for block");
+            info!(block_number, "SNOS PIE generated for block");
 
             let out = BlockInfo {
                 number: block_number,
@@ -143,7 +143,7 @@ where
             };
 
             if task_tx.send(out).await.is_err() {
-                error!(block_number; "Failed to forward block after PIE generation");
+                error!(block_number, "Failed to forward block after PIE generation");
             }
         }
     }

--- a/bin/persistent/src/utils.rs
+++ b/bin/persistent/src/utils.rs
@@ -10,7 +10,6 @@ use cairo_vm::{
     vm::runners::cairo_pie::CairoPie,
 };
 use integrity::Felt;
-use log::debug;
 use num_traits::ToPrimitive;
 use starknet::{
     core::types::{Call, ExecutionResult, StarknetError, TransactionReceiptWithBlockInfo},
@@ -18,6 +17,7 @@ use starknet::{
 };
 use swiftness_air::types::SegmentInfo;
 use swiftness_stark::types::StarkProof;
+use tracing::debug;
 
 const STARKNET_TX_CALLDATA_LIMIT: usize = 5_000;
 

--- a/saya/core/Cargo.toml
+++ b/saya/core/Cargo.toml
@@ -17,7 +17,6 @@ celestia-types.workspace = true
 ciborium.workspace = true
 futures-util.workspace = true
 hex.workspace = true
-log.workspace = true
 num-traits.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -28,6 +27,7 @@ swiftness_stark = { git = "https://github.com/chudkowsky/swiftness", rev = "e07d
 thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
+tracing.workspace = true
 url.workspace = true
 sqlx.workspace = true
 starknet_api.workspace = true

--- a/saya/core/src/block_ingestor/polling.rs
+++ b/saya/core/src/block_ingestor/polling.rs
@@ -1,7 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
 use anyhow::Result;
-use log::{debug, error, trace};
 use starknet::{
     core::types::BlockId,
     providers::{jsonrpc::HttpTransport, JsonRpcClient, Provider},
@@ -14,6 +13,7 @@ use tokio::{
     task,
     time::sleep,
 };
+use tracing::{debug, error, trace};
 use url::Url;
 
 use crate::{
@@ -75,7 +75,7 @@ where
         match block_number {
             Ok(block_number) => Some(block_number),
             Err(err) => {
-                error!(error:? = err; "Failed to fetch latest block");
+                error!(error = ?err, "Failed to fetch latest block");
                 None
             }
         }
@@ -122,7 +122,7 @@ where
                 .await
                 .unwrap();
 
-            trace!(block_number; "Block mined, forwarding downstream");
+            trace!(block_number, "Block mined, forwarding downstream");
 
             let new_block = BlockInfo {
                 number: block_number,
@@ -131,7 +131,7 @@ where
             };
 
             if channel.send(new_block).await.is_err() {
-                error!(block_number; "Failed to send block");
+                error!(block_number, "Failed to send block");
             }
         }
     }
@@ -363,7 +363,7 @@ where
         match block_number {
             Ok(n) => Some(n),
             Err(err) => {
-                error!(error:? = err; "Failed to fetch latest block");
+                error!(error = ?err, "Failed to fetch latest block");
                 None
             }
         }
@@ -395,7 +395,7 @@ where
             .add_state_update(block_number.try_into()?, state_update.clone())
             .await?;
 
-        trace!(block_number; "Block fetched, buffering for next batch");
+        trace!(block_number, "Block fetched, buffering for next batch");
 
         Ok(BlockInfo {
             number: block_number,
@@ -430,16 +430,16 @@ where
                                 }
                             }
                             Err(e) => {
-                                error!(block_id, error:% = e; "Failed to re-fetch failed block");
+                                error!(block_id, error = %e, "Failed to re-fetch failed block");
                             }
                         }
                     }
                     if let Err(e) = self.db.mark_failed_blocks_as_handled(&block_ids).await {
-                        error!(error:% = e; "Failed to mark failed blocks as handled");
+                        error!(error = %e, "Failed to mark failed blocks as handled");
                     }
                 }
                 Ok(_) => {}
-                Err(e) => error!(error:% = e; "Failed to query failed blocks"),
+                Err(e) => error!(error = %e, "Failed to query failed blocks"),
             }
 
             // Advance to the next block in sequence.
@@ -471,7 +471,7 @@ where
                     Err(e) => {
                         error!(
                             block_number = self.current_block,
-                            error:% = e;
+                            error = %e,
                             "Failed to fetch block, retrying"
                         );
                         tokio::select! {
@@ -486,7 +486,7 @@ where
                     _ = sleep(BLOCK_CHECK_INTERVAL) => {}
                     _ = tokio::time::sleep_until(idle_deadline) => {
                         if !pending.is_empty() {
-                            debug!(count = pending.len(); "Idle timeout — flushing partial batch");
+                            debug!(count = pending.len(), "Idle timeout — flushing partial batch");
                             let batch = std::mem::take(&mut pending);
                             if self.channel.send(batch).await.is_err() {
                                 break 'outer;

--- a/saya/core/src/data_availability/celestia.rs
+++ b/saya/core/src/data_availability/celestia.rs
@@ -2,9 +2,9 @@ use anyhow::Result;
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use celestia_rpc::{BlobClient, Client, TxConfig};
 use celestia_types::{nmt::Namespace, AppVersion, Blob};
-use log::{debug, info};
 use starknet_types_core::felt::Felt;
 use tokio::sync::mpsc::{Receiver, Sender};
+use tracing::{debug, info};
 use url::Url;
 
 use crate::{
@@ -81,8 +81,8 @@ where
 
             debug!(
                 block_number = new_proof.block_number(),
-                commitment:? = hex::encode(commitment),
-                blob_bytes_size = blob.data.len();
+                commitment = ?hex::encode(commitment),
+                blob_bytes_size = blob.data.len(),
                 "Submitting Celestia DA blob.",
             );
 
@@ -98,8 +98,8 @@ where
             info!(
                 block_number = new_proof.block_number(),
                 celestia_block,
-                namespace:? = STANDARD.encode(self.namespace.as_bytes()),
-                commitment:? = hex::encode(commitment);
+                namespace = ?STANDARD.encode(self.namespace.as_bytes()),
+                commitment = ?hex::encode(commitment),
                 "Blob posted on Celestia."
             );
 

--- a/saya/core/src/data_availability/noop.rs
+++ b/saya/core/src/data_availability/noop.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use log::debug;
 use tokio::sync::mpsc::{Receiver, Sender};
+use tracing::debug;
 
 use crate::{
     data_availability::{

--- a/saya/core/src/orchestrator/persistent_tee.rs
+++ b/saya/core/src/orchestrator/persistent_tee.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use log::{debug, info};
 use tokio::sync::mpsc::Receiver;
+use tracing::{debug, info};
 
 use crate::{
     block_ingestor::{BlockInfo, BlockIngestor, BlockIngestorBuilder},
@@ -146,7 +146,7 @@ impl PersistentTeeOrchestratorState {
 
             info!(
                 block_number = new_cursor.block_number,
-                transaction_hash:% = format!("{:#064x}", new_cursor.transaction_hash);
+                transaction_hash = %format!("{:#064x}", new_cursor.transaction_hash),
                 "Chain advanced to new block"
             );
         }

--- a/saya/core/src/orchestrator/tee.rs
+++ b/saya/core/src/orchestrator/tee.rs
@@ -15,8 +15,8 @@
 //! ```
 
 use anyhow::Result;
-use log::{debug, info};
 use tokio::sync::mpsc::Receiver;
+use tracing::{debug, info};
 
 use crate::{
     block_ingestor::{BatchingBlockIngestorBuilder, BlockInfo, BlockIngestor},
@@ -144,7 +144,7 @@ impl TeeOrchestratorState {
 
             info!(
                 block_number = new_cursor.block_number,
-                transaction_hash:% = format!("{:#064x}", new_cursor.transaction_hash);
+                transaction_hash = %format!("{:#064x}", new_cursor.transaction_hash),
                 "Chain advanced to new block"
             );
         }

--- a/saya/core/src/prover/block_orderer.rs
+++ b/saya/core/src/prover/block_orderer.rs
@@ -1,8 +1,8 @@
 use std::{collections::BTreeMap, marker::PhantomData};
 
 use anyhow::Result;
-use log::debug;
 use tokio::sync::mpsc::{Receiver, Sender};
+use tracing::debug;
 
 use crate::{
     prover::{HasBlockNumber, PipelineStage, PipelineStageBuilder},

--- a/saya/core/src/prover/recursive.rs
+++ b/saya/core/src/prover/recursive.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use log::debug;
 use tokio::sync::mpsc::{Receiver, Sender};
+use tracing::debug;
 
 use crate::{
     prover::{PipelineStage, PipelineStageBuilder},

--- a/saya/core/src/prover/tee/mod.rs
+++ b/saya/core/src/prover/tee/mod.rs
@@ -4,8 +4,8 @@
 //! same [`PipelineStageBuilder`] interface.
 
 use anyhow::Result;
-use log::debug;
 use tokio::sync::mpsc::{Receiver, Sender};
+use tracing::debug;
 
 use starknet_types_core::felt::Felt;
 

--- a/saya/core/src/storage/sql_lite/mod.rs
+++ b/saya/core/src/storage/sql_lite/mod.rs
@@ -3,11 +3,11 @@ use std::path::Path;
 use std::time::Duration;
 
 use anyhow::Error;
-use log::trace;
 use sqlx::query;
 use sqlx::sqlite::SqlitePoolOptions;
 use sqlx::Pool;
 use sqlx::Sqlite;
+use tracing::trace;
 
 mod storage;
 mod utils;
@@ -25,13 +25,13 @@ impl SqliteDb {
 
         if path != IN_MEMORY_DB && !path_file.try_exists()? {
             trace!(
-                database_path:% = path;
+                database_path = %path,
                 "Database file not found. A new one will be created. ",
             );
             fs::create_dir_all(path_file.parent().unwrap())?;
             fs::File::create(path_file)?;
         } else {
-            trace!(database_path:% = path; "Database file found.");
+            trace!(database_path = %path, "Database file found.");
         }
 
         let pool = SqlitePoolOptions::new()

--- a/saya/core/src/utils.rs
+++ b/saya/core/src/utils.rs
@@ -1,6 +1,6 @@
 use std::{future::Future, time::Duration};
 
-use log::debug;
+use tracing::debug;
 
 pub async fn retry_with_backoff<F, Fut, T, E>(
     operation: F,

--- a/saya/tracing/Cargo.toml
+++ b/saya/tracing/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "saya-tracing"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Tracing/logging initialization for Saya binaries."
+
+[dependencies]
+chrono = { workspace = true }
+thiserror.workspace = true
+tracing = { workspace = true }
+tracing-log = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/saya/tracing/src/fmt.rs
+++ b/saya/tracing/src/fmt.rs
@@ -1,0 +1,27 @@
+use tracing_subscriber::fmt::format::Writer;
+use tracing_subscriber::fmt::time;
+
+const DEFAULT_TIMESTAMP_FORMAT: &str = "%Y-%m-%d %H:%M:%S%.3f %Z";
+
+/// Default formatter for span and event timestamps.
+///
+/// Formats timestamps in local time with the following format:
+///
+/// ```console
+/// %Y-%m-%d %H:%M:%S%.3f %Z
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct LocalTime;
+
+impl LocalTime {
+    pub fn new() -> Self {
+        LocalTime
+    }
+}
+
+impl time::FormatTime for LocalTime {
+    fn format_time(&self, w: &mut Writer<'_>) -> std::fmt::Result {
+        let time = chrono::Local::now();
+        write!(w, "{}", time.format(DEFAULT_TIMESTAMP_FORMAT))
+    }
+}

--- a/saya/tracing/src/lib.rs
+++ b/saya/tracing/src/lib.rs
@@ -1,0 +1,44 @@
+use std::io::IsTerminal;
+
+use tracing::subscriber::SetGlobalDefaultError;
+use tracing_log::log::SetLoggerError;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{filter, EnvFilter};
+
+mod fmt;
+
+pub use fmt::LocalTime;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("failed to initialize log tracer: {0}")]
+    LogTracerInit(#[from] SetLoggerError),
+
+    #[error("failed to parse environment filter: {0}")]
+    EnvFilterParse(#[from] filter::ParseError),
+
+    #[error("failed to set global dispatcher: {0}")]
+    SetGlobalDefault(#[from] SetGlobalDefaultError),
+}
+
+/// Installs the process-wide tracing subscriber.
+///
+/// Reads the env filter from `RUST_LOG`; falls back to `default_filter` if unset.
+/// Enables ANSI colors when stdout is a terminal. Bridges `log` crate records from
+/// dependencies into the tracing subscriber.
+pub fn init(default_filter: &str) -> Result<(), Error> {
+    let filter =
+        EnvFilter::try_from_default_env().or_else(|_| EnvFilter::try_new(default_filter))?;
+
+    let stdout_layer = tracing_subscriber::fmt::layer()
+        .with_timer(LocalTime::new())
+        .with_ansi(std::io::stdout().is_terminal());
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(stdout_layer)
+        .init();
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Adopt the same tracing stack katana uses so log output format matches (katana-style `%Y-%m-%d %H:%M:%S%.3f %Z` local-time timestamps) and the pipeline is ready for future OTLP/GCloud exporters.
- New `saya-tracing` crate mirrors katana's tracing layout (minus file sink / OTLP / GCloud): exports a `LocalTime` formatter and a single `init(default_filter)` entry point. `tracing-log`'s LogTracer is installed via tracing-subscriber's feature so `log::*` calls from dependencies still flow through.
- Swap `log` / `env_logger` for `tracing` across `saya-core` and all three bins (`persistent`, `persistent-tee`, `ops`); convert kv-style macro calls (`key:? = val; "msg"`) to tracing field syntax (`key = ?val, "msg"`).
- Each bin's `main.rs` now calls `saya_tracing::init("…filter…")?` in place of the old `set_var` + `env_logger::init()` pair.
