### PR TITLE
chore(piltover): align with new `ProgramInfo` enum + plumb `katana_tee_config_hash`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4115,7 +4115,7 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 [[package]]
 name = "piltover"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/piltover.git?rev=dc86b13de0713c172153c4833fd7b3d14a855351#dc86b13de0713c172153c4833fd7b3d14a855351"
+source = "git+https://github.com/cartridge-gg/piltover.git?branch=feat%2Ftee-persistent#ebb714b3a0e63da8088ea4f371bcca2a1a3f74f0"
 dependencies = [
  "cainome",
  "starknet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ tokio-util = { version = "0.7.13", default-features = false }
 url = { version = "2.5.4", default-features = false }
 zip = { version = "2.2.2", default-features = false, features = ["deflate"] }
 sqlx = { version = "0.8.2", features = [ "chrono", "macros", "regexp", "runtime-async-std", "runtime-tokio", "sqlite", "uuid" ] }
-piltover = {package = "piltover", git = "https://github.com/cartridge-gg/piltover.git", rev = "dc86b13de0713c172153c4833fd7b3d14a855351" }
+piltover = {package = "piltover", git = "https://github.com/cartridge-gg/piltover.git", branch = "feat/tee-persistent" }
 cainome = { version = "0.10.1", features = ["abigen-rs"] }
 generate-pie = {git = "https://github.com/keep-starknet-strange/snos.git",rev = "6cf7040"}
 

--- a/bin/ops/src/core_contract/utils.rs
+++ b/bin/ops/src/core_contract/utils.rs
@@ -201,10 +201,15 @@ pub async fn set_program_info(
     let txn_config = TxnConfig::default();
     let invoker = Invoker::new(account, txn_config);
 
+    // `ProgramInfo` is a Cairo enum (StarknetOs / KatanaTee). Cairo serializes an enum
+    // as `[variant_index, ...inner_struct_fields]`. `ops` only deploys for the
+    // validity-proof path, so always emit the `StarknetOs` variant (index 0) followed
+    // by the four `StarknetOsProgramInfo` fields in declaration order.
     let call = Call {
         to: contract_address,
         selector: selector!("set_program_info"),
         calldata: vec![
+            Felt::ZERO, // ProgramInfo::StarknetOs variant index
             BOOTLOADER_PROGRAM_HASH,
             snos_config_hash,
             SNOS_PROGRAM_HASH,

--- a/bin/persistent-tee/Cargo.lock
+++ b/bin/persistent-tee/Cargo.lock
@@ -731,7 +731,7 @@ dependencies = [
 [[package]]
 name = "amd-sev-snp-attestation-prover"
 version = "0.1.0"
-source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=56aa752d2e73e505c356c80b7a00eddd27d4d263#56aa752d2e73e505c356c80b7a00eddd27d4d263"
+source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=649f0864434ea7895a977318e502b4e19666d10b#649f0864434ea7895a977318e502b4e19666d10b"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -762,7 +762,7 @@ dependencies = [
 [[package]]
 name = "amd-sev-snp-attestation-verifier"
 version = "0.1.0"
-source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=56aa752d2e73e505c356c80b7a00eddd27d4d263#56aa752d2e73e505c356c80b7a00eddd27d4d263"
+source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=649f0864434ea7895a977318e502b4e19666d10b#649f0864434ea7895a977318e502b4e19666d10b"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "amd_tee_registry_client"
 version = "0.1.0"
-source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=56aa752d2e73e505c356c80b7a00eddd27d4d263#56aa752d2e73e505c356c80b7a00eddd27d4d263"
+source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=649f0864434ea7895a977318e502b4e19666d10b#649f0864434ea7895a977318e502b4e19666d10b"
 dependencies = [
  "alloy-primitives",
  "amd-sev-snp-attestation-prover",
@@ -5428,7 +5428,7 @@ checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 [[package]]
 name = "garaga_rs"
 version = "1.0.1"
-source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=56aa752d2e73e505c356c80b7a00eddd27d4d263#56aa752d2e73e505c356c80b7a00eddd27d4d263"
+source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=649f0864434ea7895a977318e502b4e19666d10b#649f0864434ea7895a977318e502b4e19666d10b"
 dependencies = [
  "arbitrary",
  "getrandom 0.3.4",
@@ -6720,7 +6720,7 @@ dependencies = [
 [[package]]
 name = "katana_tee_client"
 version = "0.1.0"
-source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=56aa752d2e73e505c356c80b7a00eddd27d4d263#56aa752d2e73e505c356c80b7a00eddd27d4d263"
+source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=649f0864434ea7895a977318e502b4e19666d10b#649f0864434ea7895a977318e502b4e19666d10b"
 dependencies = [
  "amd-sev-snp-attestation-prover",
  "amd_tee_registry_client",
@@ -8265,7 +8265,7 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 [[package]]
 name = "piltover"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/piltover.git?rev=dc86b13de0713c172153c4833fd7b3d14a855351#dc86b13de0713c172153c4833fd7b3d14a855351"
+source = "git+https://github.com/cartridge-gg/piltover.git?branch=feat%2Ftee-persistent#ebb714b3a0e63da8088ea4f371bcca2a1a3f74f0"
 dependencies = [
  "cainome",
  "starknet",
@@ -9308,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "risc0-methods"
 version = "0.1.0"
-source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=56aa752d2e73e505c356c80b7a00eddd27d4d263#56aa752d2e73e505c356c80b7a00eddd27d4d263"
+source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=649f0864434ea7895a977318e502b4e19666d10b#649f0864434ea7895a977318e502b4e19666d10b"
 dependencies = [
  "lazy_static",
  "risc0-build",
@@ -10715,7 +10715,7 @@ dependencies = [
 [[package]]
 name = "sp1-methods"
 version = "0.1.0"
-source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=56aa752d2e73e505c356c80b7a00eddd27d4d263#56aa752d2e73e505c356c80b7a00eddd27d4d263"
+source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=649f0864434ea7895a977318e502b4e19666d10b#649f0864434ea7895a977318e502b4e19666d10b"
 dependencies = [
  "lazy_static",
  "sp1-build",
@@ -11482,7 +11482,7 @@ dependencies = [
 [[package]]
 name = "starknet-rust-accounts"
 version = "0.17.0"
-source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=56aa752d2e73e505c356c80b7a00eddd27d4d263#56aa752d2e73e505c356c80b7a00eddd27d4d263"
+source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=649f0864434ea7895a977318e502b4e19666d10b#649f0864434ea7895a977318e502b4e19666d10b"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -11496,7 +11496,7 @@ dependencies = [
 [[package]]
 name = "starknet-rust-core"
 version = "0.17.0"
-source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=56aa752d2e73e505c356c80b7a00eddd27d4d263#56aa752d2e73e505c356c80b7a00eddd27d4d263"
+source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=649f0864434ea7895a977318e502b4e19666d10b#649f0864434ea7895a977318e502b4e19666d10b"
 dependencies = [
  "base64 0.21.7",
  "crypto-bigint 0.5.5",
@@ -11519,7 +11519,7 @@ dependencies = [
 [[package]]
 name = "starknet-rust-core-derive"
 version = "0.1.0"
-source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=56aa752d2e73e505c356c80b7a00eddd27d4d263#56aa752d2e73e505c356c80b7a00eddd27d4d263"
+source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=649f0864434ea7895a977318e502b4e19666d10b#649f0864434ea7895a977318e502b4e19666d10b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11529,7 +11529,7 @@ dependencies = [
 [[package]]
 name = "starknet-rust-crypto"
 version = "0.9.0"
-source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=56aa752d2e73e505c356c80b7a00eddd27d4d263#56aa752d2e73e505c356c80b7a00eddd27d4d263"
+source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=649f0864434ea7895a977318e502b4e19666d10b#649f0864434ea7895a977318e502b4e19666d10b"
 dependencies = [
  "blake2",
  "crypto-bigint 0.5.5",
@@ -11549,7 +11549,7 @@ dependencies = [
 [[package]]
 name = "starknet-rust-curve"
 version = "0.6.0"
-source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=56aa752d2e73e505c356c80b7a00eddd27d4d263#56aa752d2e73e505c356c80b7a00eddd27d4d263"
+source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=649f0864434ea7895a977318e502b4e19666d10b#649f0864434ea7895a977318e502b4e19666d10b"
 dependencies = [
  "starknet-types-core 0.2.4",
 ]
@@ -11557,7 +11557,7 @@ dependencies = [
 [[package]]
 name = "starknet-rust-providers"
 version = "0.17.0"
-source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=56aa752d2e73e505c356c80b7a00eddd27d4d263#56aa752d2e73e505c356c80b7a00eddd27d4d263"
+source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=649f0864434ea7895a977318e502b4e19666d10b#649f0864434ea7895a977318e502b4e19666d10b"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -11577,7 +11577,7 @@ dependencies = [
 [[package]]
 name = "starknet-rust-signers"
 version = "0.15.0"
-source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=56aa752d2e73e505c356c80b7a00eddd27d4d263#56aa752d2e73e505c356c80b7a00eddd27d4d263"
+source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=649f0864434ea7895a977318e502b4e19666d10b#649f0864434ea7895a977318e502b4e19666d10b"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -13610,7 +13610,7 @@ dependencies = [
 [[package]]
 name = "x509-verifier-rust-crypto"
 version = "0.1.0"
-source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=56aa752d2e73e505c356c80b7a00eddd27d4d263#56aa752d2e73e505c356c80b7a00eddd27d4d263"
+source = "git+ssh://git@github.com/cartridge-gg/katana-tee.git?rev=649f0864434ea7895a977318e502b4e19666d10b#649f0864434ea7895a977318e502b4e19666d10b"
 dependencies = [
  "alloy-primitives",
  "anyhow",

--- a/bin/persistent-tee/Cargo.toml
+++ b/bin/persistent-tee/Cargo.toml
@@ -20,14 +20,14 @@ repository.workspace = true
 
 [dependencies]
 saya-core = { path = "../../saya/core" }
-katana_tee_client = { git = "ssh://git@github.com/cartridge-gg/katana-tee.git", rev = "56aa752d2e73e505c356c80b7a00eddd27d4d263" }
-amd-sev-snp-attestation-prover = { git = "ssh://git@github.com/cartridge-gg/katana-tee.git", rev = "56aa752d2e73e505c356c80b7a00eddd27d4d263", features = ["sp1"] }
-amd-sev-snp-attestation-verifier = { git = "ssh://git@github.com/cartridge-gg/katana-tee.git", rev = "56aa752d2e73e505c356c80b7a00eddd27d4d263" }
-amd_tee_registry_client = { git = "ssh://git@github.com/cartridge-gg/katana-tee.git", rev = "56aa752d2e73e505c356c80b7a00eddd27d4d263" }
-x509-verifier-rust-crypto = { git = "ssh://git@github.com/cartridge-gg/katana-tee.git", rev = "56aa752d2e73e505c356c80b7a00eddd27d4d263" }
+katana_tee_client = { git = "ssh://git@github.com/cartridge-gg/katana-tee.git", rev = "649f0864434ea7895a977318e502b4e19666d10b" }
+amd-sev-snp-attestation-prover = { git = "ssh://git@github.com/cartridge-gg/katana-tee.git", rev = "649f0864434ea7895a977318e502b4e19666d10b", features = ["sp1"] }
+amd-sev-snp-attestation-verifier = { git = "ssh://git@github.com/cartridge-gg/katana-tee.git", rev = "649f0864434ea7895a977318e502b4e19666d10b" }
+amd_tee_registry_client = { git = "ssh://git@github.com/cartridge-gg/katana-tee.git", rev = "649f0864434ea7895a977318e502b4e19666d10b" }
+x509-verifier-rust-crypto = { git = "ssh://git@github.com/cartridge-gg/katana-tee.git", rev = "649f0864434ea7895a977318e502b4e19666d10b" }
 alloy-primitives = "1.3.1"
 
-piltover = { package = "piltover", git = "https://github.com/cartridge-gg/piltover.git", rev = "dc86b13de0713c172153c4833fd7b3d14a855351" }
+piltover = { package = "piltover", git = "https://github.com/cartridge-gg/piltover.git", branch = "feat/tee-persistent" }
 cainome = { version = "0.10.1", features = ["abigen-rs"] }
 sha3 = "0.10"
 

--- a/bin/persistent-tee/src/attestor.rs
+++ b/bin/persistent-tee/src/attestor.rs
@@ -174,6 +174,7 @@ impl TeeAttestor {
             messages_commitment: attestation.messages_commitment,
             l2_to_l1_messages,
             l1_to_l2_messages,
+            katana_tee_config_hash: attestation.katana_tee_config_hash,
         })
     }
 }

--- a/bin/persistent-tee/src/prover.rs
+++ b/bin/persistent-tee/src/prover.rs
@@ -136,6 +136,7 @@ impl TeeProver {
             messages_commitment: attestation.messages_commitment,
             l2_to_l1_messages: vec![],
             l1_to_l2_messages: vec![],
+            katana_tee_config_hash: attestation.katana_tee_config_hash,
         };
 
         let tee = TeeAttestationProver::from_response(&response)?;
@@ -167,6 +168,7 @@ impl TeeProver {
             messages_commitment: attestation.messages_commitment,
             l2_to_l1_messages: attestation.l2_to_l1_messages,
             l1_to_l2_messages: attestation.l1_to_l2_messages,
+            katana_tee_config_hash: attestation.katana_tee_config_hash,
         })
     }
 }

--- a/bin/persistent-tee/src/settlement.rs
+++ b/bin/persistent-tee/src/settlement.rs
@@ -94,6 +94,7 @@ fn build_tee_calldata(proof: &TeeProof) -> Result<Vec<Felt>> {
         messages_to_starknet: messages_to_starknet(&proof.l2_to_l1_messages),
         messages_to_appchain: messages_to_appchain(&proof.l1_to_l2_messages),
         l1_to_l2_msg_hashes,
+        katana_tee_config_hash: proof.katana_tee_config_hash,
     };
 
     Ok(PiltoverInput::cairo_serialize(&PiltoverInput::TeeInput(

--- a/bin/persistent/Cargo.lock
+++ b/bin/persistent/Cargo.lock
@@ -5173,7 +5173,7 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 [[package]]
 name = "piltover"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/piltover.git?rev=67e65b8928b7ee3c2c188bf36c6b9eddc14addb2#67e65b8928b7ee3c2c188bf36c6b9eddc14addb2"
+source = "git+https://github.com/cartridge-gg/piltover.git?branch=feat%2Ftee-persistent#ebb714b3a0e63da8088ea4f371bcca2a1a3f74f0"
 dependencies = [
  "cainome",
  "starknet",

--- a/bin/persistent/Cargo.toml
+++ b/bin/persistent/Cargo.toml
@@ -29,7 +29,7 @@ generate-pie = { git = "https://github.com/keep-starknet-strange/snos.git", rev 
 hex = { version = "0.4.3", default-features = false }
 integrity = { git = "https://github.com/chudkowsky/integrity-rs.git", rev = "9729be1", default-features = false, features = ["recursive_with_poseidon", "keccak_160_lsb", "stone6"] }
 num-traits = { version = "0.2.19", default-features = false }
-piltover = { package = "piltover", git = "https://github.com/cartridge-gg/piltover.git", rev = "67e65b8928b7ee3c2c188bf36c6b9eddc14addb2" }
+piltover = { package = "piltover", git = "https://github.com/cartridge-gg/piltover.git", branch = "feat/tee-persistent" }
 cainome = { version = "0.10.1", features = ["abigen-rs"] }
 reqwest = { version = "0.12.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }
 serde = { version = "1.0.217", default-features = false, features = ["derive"] }

--- a/saya/core/src/prover/tee/mod.rs
+++ b/saya/core/src/prover/tee/mod.rs
@@ -39,6 +39,9 @@ pub struct TeeProof {
     pub l2_to_l1_messages: Vec<L2ToL1Message>,
     /// All L1→L2 messages processed in the attested block range.
     pub l1_to_l2_messages: Vec<L1ToL2Message>,
+    /// Versioned environment config hash carried through from the attestation.
+    /// Bound into Piltover's `TEEInput.katana_tee_config_hash` at settlement time.
+    pub katana_tee_config_hash: Felt,
 }
 
 impl HasBlockNumber for TeeProof {
@@ -152,6 +155,7 @@ impl TeeProver {
             messages_commitment: attestation.messages_commitment,
             l2_to_l1_messages: attestation.l2_to_l1_messages,
             l1_to_l2_messages: attestation.l1_to_l2_messages,
+            katana_tee_config_hash: attestation.katana_tee_config_hash,
         }
     }
 }

--- a/saya/core/src/tee/mod.rs
+++ b/saya/core/src/tee/mod.rs
@@ -50,6 +50,11 @@ pub struct TeeAttestation {
     pub l2_to_l1_messages: Vec<L2ToL1Message>,
     /// All L1→L2 messages processed in the attested block range.
     pub l1_to_l2_messages: Vec<L1ToL2Message>,
+    /// Versioned environment config hash bound into v1 SEV-SNP `report_data`.
+    /// Sourced from the Katana RPC response and threaded to the on-chain
+    /// `TEEInput.katana_tee_config_hash` so Piltover's runtime invariant
+    /// (`tee_input == KatanaTeeProgramInfo.katana_tee_config_hash`) holds.
+    pub katana_tee_config_hash: Felt,
 }
 
 impl HasBlockNumber for TeeAttestation {

--- a/tests/e2e/tests/settlement.rs
+++ b/tests/e2e/tests/settlement.rs
@@ -1,3 +1,4 @@
+use piltover::ProgramInfo;
 use saya_e2e::{
     compose_up, env, get_facts_registry, get_program_info, provider, wait_for_settlement,
     ComposeGuard,
@@ -38,16 +39,17 @@ async fn test_program_info_and_fact_registry() {
         env::fee_token_address(),
     ]);
 
-    assert_eq!(
-        program_info.bootloader_program_hash,
-        BOOTLOADER_PROGRAM_HASH
-    );
-    assert_eq!(program_info.snos_program_hash, SNOS_PROGRAM_HASH);
-    assert_eq!(
-        program_info.layout_bridge_program_hash,
-        LAYOUT_BRIDGE_PROGRAM_HASH
-    );
-    assert_eq!(program_info.snos_config_hash, snos_config_hash);
+    let info = match program_info {
+        ProgramInfo::StarknetOs(info) => info,
+        ProgramInfo::KatanaTee(_) => {
+            panic!("e2e settlement test expects StarknetOs config, got KatanaTee variant")
+        }
+    };
+
+    assert_eq!(info.bootloader_program_hash, BOOTLOADER_PROGRAM_HASH);
+    assert_eq!(info.snos_program_hash, SNOS_PROGRAM_HASH);
+    assert_eq!(info.layout_bridge_program_hash, LAYOUT_BRIDGE_PROGRAM_HASH);
+    assert_eq!(info.snos_config_hash, snos_config_hash);
     assert_eq!(facts_registry, env::fact_registry_address());
 }
 


### PR DESCRIPTION
## Summary

Aligns Saya with `cartridge-gg/piltover#feat/tee-persistent`'s `ProgramInfo` enum split, and threads the new `katana_tee_config_hash` field from the Katana RPC response through the TEE pipeline into the on-chain `TEEInput`.

## Why

Piltover now identifies the appchain via two distinct variants:

```cairo
enum ProgramInfo {
    StarknetOs(StarknetOsProgramInfo),  // 4 SNOS-related hashes
    KatanaTee(KatanaTeeProgramInfo),    // 1 katana_tee_config_hash (Pedersen array)
}
```

Each deployment commits to one variant; `validate_input` panics on cross-mode submission. For the TEE path, `validate_input` also asserts `tee_input.katana_tee_config_hash == KatanaTeeProgramInfo.katana_tee_config_hash`, so Saya needs to source that exact value (the one Katana attested) and pass it through.

## Changes

- **3 Cargo.toml piltover repoints** to `cartridge-gg/piltover#feat/tee-persistent`. Single source of truth across root + `bin/persistent` + `bin/persistent-tee`.
- **5 Cargo.toml katana-tee revs bumped** to `649f0864` (head of `feat/test-block-0` after `cartridge-gg/katana-tee#1`). `TeeQuoteResponse` now exposes `katana_tee_config_hash`.
- **`bin/ops/src/core_contract/utils.rs::set_program_info`** prepends `Felt::ZERO` (the `StarknetOs` variant index) to the calldata. `ops` stays ZK-only; symmetric TEE-mode deployment is a separate task.
- **`saya/core::TeeAttestation` / `TeeProof`** gain `katana_tee_config_hash: Felt`.
- **`bin/persistent-tee/src/{attestor,prover,settlement}.rs`** plumb the field through: attestor lifts it off the RPC response, prover threads it through both the `TeeQuoteResponse` round-trip and `TeeProof`, settlement passes it to `TEEInput.katana_tee_config_hash`.
- **`tests/e2e/tests/settlement.rs`** matches the `StarknetOs` variant before reading the four hash fields. Same asserts, one extra match at the top.

## What does NOT change

- `LayoutBridgeOutputNoDa` / `LayoutBridgeOutputWithDa` wire format — `bin/persistent` validity-proof code is byte-identical.
- `TeeInput` outer wire shape — only the new field is added; everything else flows through unchanged.
- `bin/persistent` Saya logic — only the dep bump.
- The placeholder TeeProver in `saya/core/src/prover/tee/mod.rs` — also threads the field through.

## Cross-repo

| Repo | PR | Status |
|---|---|---|
| `cartridge-gg/piltover` | #16 | merged |
| `cartridge-gg/katana-tee` | #1 | merged |
| `dojoengine/katana` | #556 | open (the producer side) |
| `dojoengine/saya` | this PR | here |
